### PR TITLE
Rewrite matchers as ADTs

### DIFF
--- a/rust/src/enhancers/rules.rs
+++ b/rust/src/enhancers/rules.rs
@@ -10,8 +10,8 @@ use super::ExceptionData;
 pub struct Rule(pub(crate) Arc<RuleInner>);
 
 pub struct RuleInner {
-    pub frame_matchers: Vec<Arc<dyn FrameMatcher + Send + Sync>>,
-    pub exception_matchers: Vec<Arc<dyn ExceptionMatcher + Send + Sync>>,
+    pub frame_matchers: Vec<FrameMatcher>,
+    pub exception_matchers: Vec<ExceptionMatcher>,
     pub actions: Vec<Action>,
 }
 


### PR DESCRIPTION
This rewrites matchers without use of traits or dynamic dispatch. They are actually very easily expressed as an enum because there are so few different cases.