### PR TITLE
Simplify enhancers::Cache

### DIFF
--- a/rust/benches/enhancers.rs
+++ b/rust/benches/enhancers.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use divan::{black_box, Bencher};
 
-use rust_ophio::enhancers::{Enhancements, ExceptionData, Frame, LruCache, NoopCache};
+use rust_ophio::enhancers::{Cache, Enhancements, ExceptionData, Frame};
 use smol_str::SmolStr;
 
 fn main() {
@@ -25,14 +25,14 @@ fn read_fixture(name: &str) -> String {
 fn parse_enhancers(bencher: Bencher) {
     let enhancers = read_fixture("newstyle@2023-01-11.txt");
     bencher.bench(|| {
-        black_box(Enhancements::parse(&enhancers, NoopCache).unwrap());
+        black_box(Enhancements::parse(&enhancers, &mut Cache::default()).unwrap());
     })
 }
 
 #[divan::bench]
 fn parse_enhancers_cached(bencher: Bencher) {
     let enhancers = read_fixture("newstyle@2023-01-11.txt");
-    let mut cache = LruCache::new(1_000.try_into().unwrap());
+    let mut cache = Cache::new(1_000);
     bencher.bench_local(|| {
         black_box(Enhancements::parse(&enhancers, &mut cache).unwrap());
     })
@@ -41,7 +41,7 @@ fn parse_enhancers_cached(bencher: Bencher) {
 #[divan::bench]
 fn apply_modifications(bencher: Bencher) {
     let enhancers = read_fixture("newstyle@2023-01-11.txt");
-    let enhancers = Enhancements::parse(&enhancers, NoopCache).unwrap();
+    let enhancers = Enhancements::parse(&enhancers, &mut Cache::default()).unwrap();
 
     let platform = "cocoa";
 

--- a/rust/src/enhancers/actions.rs
+++ b/rust/src/enhancers/actions.rs
@@ -101,13 +101,13 @@ impl Action {
 mod tests {
     use serde_json::json;
 
-    use crate::enhancers::{Enhancements, NoopCache};
+    use crate::enhancers::{Cache, Enhancements};
 
     use super::*;
 
     #[test]
     fn in_app_modification() {
-        let enhancements = Enhancements::parse("app:no +app", NoopCache).unwrap();
+        let enhancements = Enhancements::parse("app:no +app", &mut Cache::default()).unwrap();
 
         let mut frames = vec![
             Frame::from_test(&json!({"function": "foo"}), "native"),

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -25,7 +25,7 @@ pub struct Enhancements {
 }
 
 impl Enhancements {
-    pub fn parse(input: &str, mut cache: impl Cache) -> anyhow::Result<Self> {
+    pub fn parse(input: &str, cache: &mut Cache) -> anyhow::Result<Self> {
         let mut all_rules = vec![];
 
         for line in input.lines() {
@@ -96,6 +96,6 @@ mod tests {
     fn parses_default_enhancers() {
         let enhancers =
             std::fs::read_to_string("../tests/fixtures/newstyle@2023-01-11.txt").unwrap();
-        Enhancements::parse(&enhancers, NoopCache).unwrap();
+        Enhancements::parse(&enhancers, &mut Cache::default()).unwrap();
     }
 }


### PR DESCRIPTION
Removes the `Cache` trait and turns the implementation into, essentially, an `Option<LruCache>`.