### PR TITLE
Implement Display for matchers

### DIFF
--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use smol_str::SmolStr;
 
 pub type StringField = SmolStr;
@@ -21,6 +23,19 @@ pub enum FrameField {
     Module,
     Package,
     Path,
+}
+
+impl fmt::Display for FrameField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FrameField::Category => write!(f, "category"),
+            FrameField::Family => write!(f, "family"),
+            FrameField::Function => write!(f, "function"),
+            FrameField::Module => write!(f, "module"),
+            FrameField::Package => write!(f, "package"),
+            FrameField::Path => write!(f, "path"),
+        }
+    }
 }
 
 impl Frame {


### PR DESCRIPTION
Printing a "paper trail" of matchers is AFAICT one of the purposes of enhancers. This means we should implement `Display` for matchers. I'm not thrilled about the addition of another `SmolStr` field to every matcher, but I can't see a better way to represent a matcher's pattern as it was originally written.