### PR TITLE
Apply rules in a second pass 

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -51,6 +51,15 @@ pub struct Enhancements(enhancers::Enhancements);
 
 #[pymethods]
 impl Enhancements {
+    #[staticmethod]
+    fn empty() -> Self {
+        Self(enhancers::Enhancements::default())
+    }
+
+    fn extend_from(&mut self, other: &Self) {
+        self.0.extend_from(&other.0)
+    }
+
     #[new]
     fn new(input: &str, cache: &mut Cache) -> PyResult<Self> {
         let inner = enhancers::Enhancements::parse(input, &mut cache.0)?;

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -18,7 +18,7 @@ pub struct ExceptionData {
     pub mechanism: Option<SmolStr>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Enhancements {
     pub(crate) all_rules: Vec<Rule>,
     modifier_rules: Vec<Rule>,

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -54,15 +54,19 @@ impl Enhancements {
         frames: &mut [Frame],
         exception_data: &ExceptionData,
     ) {
+        let mut matching_frames = Vec::with_capacity(frames.len());
         for rule in &self.modifier_rules {
             if !rule.matches_exception(exception_data) {
                 continue;
             }
 
-            for idx in 0..frames.len() {
-                if rule.matches_frame(frames, idx) {
-                    rule.apply_modifications_to_frame(frames, idx);
-                }
+            // first, for each frame check if the rule matches
+            matching_frames
+                .extend((0..frames.len()).filter(|idx| rule.matches_frame(frames, *idx)));
+
+            // then in a second pass, apply the actions to all matching frames
+            for idx in matching_frames.drain(..) {
+                rule.apply_modifications_to_frame(frames, idx);
             }
         }
     }


### PR DESCRIPTION
This solves the mystery why python returns an intermediate list in `get_matching_frame_actions`.
The algorithm has to run in two passes, because caller/callee matchers could observe modifications.