### PR TITLE
Rename Enhancements.__new__ to parse

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -56,8 +56,8 @@ impl Enhancements {
         Self(enhancers::Enhancements::default())
     }
 
-    #[new]
-    fn new(input: &str, cache: &mut Cache) -> PyResult<Self> {
+    #[staticmethod]
+    fn parse(input: &str, cache: &mut Cache) -> PyResult<Self> {
         let inner = enhancers::Enhancements::parse(input, &mut cache.0)?;
         Ok(Self(inner))
     }

--- a/python/sentry_ophio/enhancers.pyi
+++ b/python/sentry_ophio/enhancers.pyi
@@ -13,7 +13,8 @@ class Enhancements:
     def empty() -> 'Enhancements':
         ...
 
-    def __new__(cls, input: str, cache: Cache) -> 'Enhancements':
+    @staticmethod
+    def parse(input: str, cache: Cache) -> 'Enhancements':
         ...
 
     @staticmethod

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -67,7 +67,7 @@ def create_match_frame(frame_data: dict, platform: Optional[str]) -> dict:
 
 def test_simple_enhancer():
     cache = Cache(1_000)
-    enhancer = Enhancements("path:**/test.js              +app", cache)
+    enhancer = Enhancements.parse("path:**/test.js              +app", cache)
 
     frames = [
         create_match_frame(


### PR DESCRIPTION
With the addition of `from_config_structure`, there's no longer really a canonical constructor. I think `parse` is a clearer name for this function.