### PR TITLE
Update `orig_/in_app` handling

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -11,7 +11,7 @@ pub struct Frame {
     module: OptStr,
     package: OptStr,
     path: OptStr,
-    in_app: bool,
+    in_app: Option<bool>,
 }
 
 struct OptStr(Option<enhancers::StringField>);
@@ -86,10 +86,11 @@ impl Enhancements {
                     family: frame.family.0,
                     function: frame.function.0,
                     module: frame.module.0,
-                    orig_in_app: None,
                     package: frame.package.0,
                     path: frame.path.0,
+
                     in_app: frame.in_app,
+                    orig_in_app: frame.in_app,
                 };
                 Ok(frame)
             })

--- a/rust/src/enhancers/actions.rs
+++ b/rust/src/enhancers/actions.rs
@@ -72,11 +72,7 @@ impl FlagAction {
     pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize) {
         if self.ty == FlagActionType::App {
             for frame in self.slice_to_range_mut(frames, idx) {
-                let current_in_app = frame.in_app;
-                if current_in_app != self.flag {
-                    frame.in_app = self.flag;
-                    frame.orig_in_app = frame.orig_in_app.or(Some(current_in_app));
-                }
+                frame.in_app = Some(self.flag);
             }
         }
     }
@@ -125,7 +121,7 @@ impl FlagAction {
 
     fn in_app_changed(&self, component: &Component, frame: &Frame) -> bool {
         if let Some(orig_in_app) = frame.orig_in_app {
-            orig_in_app != frame.in_app
+            Some(orig_in_app) != frame.in_app
         } else {
             self.flag == component.contributes
         }
@@ -265,7 +261,7 @@ mod tests {
 
         enhancements.apply_modifications_to_frames(&mut frames, &Default::default());
 
-        assert!(frames[0].in_app);
-        assert!(frames[1].in_app);
+        assert_eq!(frames[0].in_app, Some(true));
+        assert_eq!(frames[1].in_app, Some(true));
     }
 }

--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -9,11 +9,12 @@ pub struct Frame {
     pub category: Option<StringField>,
     pub family: Option<StringField>,
     pub function: Option<StringField>,
-    pub in_app: bool,
     pub module: Option<StringField>,
-    pub orig_in_app: Option<bool>,
     pub package: Option<StringField>,
     pub path: Option<StringField>,
+
+    pub in_app: Option<bool>,
+    pub orig_in_app: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -67,10 +68,7 @@ impl Frame {
                 .get("function")
                 .and_then(|s| s.as_str())
                 .map(SmolStr::new),
-            in_app: raw_frame
-                .get("in_app")
-                .and_then(|s| s.as_bool())
-                .unwrap_or_default(),
+            in_app: raw_frame.get("in_app").and_then(|s| s.as_bool()),
 
             module: raw_frame
                 .get("module")

--- a/rust/src/enhancers/matchers.rs
+++ b/rust/src/enhancers/matchers.rs
@@ -254,7 +254,7 @@ impl FrameMatcherInner {
 
                 families.is_empty() || families.contains(value)
             }
-            FrameMatcherInner::InApp { expected } => frame.in_app == *expected,
+            FrameMatcherInner::InApp { expected } => frame.in_app.unwrap_or_default() == *expected,
         }
     }
 }


### PR DESCRIPTION
This way the `orig_in_app` flag is not touched by the `apply_modifications_to_frame` method.