### PR TITLE
Use a bitfield for `families` and optimize that a bit more

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -83,7 +83,7 @@ impl Enhancements {
                 let frame: Frame = frame?.extract()?;
                 let frame = enhancers::Frame {
                     category: frame.category.0,
-                    family: frame.family.0,
+                    family: enhancers::Families::new(frame.family.0.as_deref().unwrap_or("other")),
                     function: frame.function.0,
                     module: frame.module.0,
                     package: frame.package.0,

--- a/rust/src/enhancers/families.rs
+++ b/rust/src/enhancers/families.rs
@@ -1,0 +1,33 @@
+#[derive(Debug, Clone, Copy)]
+pub struct Families(u8);
+
+const BITFIELD_OTHER: u8 = 0b001;
+const BITFIELD_NATIVE: u8 = 0b010;
+const BITFIELD_JAVASCRIPT: u8 = 0b100;
+const BITFIELD_ALL: u8 = u8::MAX;
+
+impl Families {
+    pub fn new(families: &str) -> Self {
+        let mut bitfield = 0;
+        for family in families.split(',') {
+            bitfield |= match family {
+                "other" => BITFIELD_OTHER,
+                "native" => BITFIELD_NATIVE,
+                "javascript" => BITFIELD_JAVASCRIPT,
+                "all" => BITFIELD_ALL,
+                _ => 0,
+            };
+        }
+        Self(bitfield)
+    }
+
+    pub fn matches(&self, other: Families) -> bool {
+        (self.0 & other.0) > 0
+    }
+}
+
+impl Default for Families {
+    fn default() -> Self {
+        Self(BITFIELD_OTHER)
+    }
+}

--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -2,12 +2,14 @@ use std::fmt;
 
 use smol_str::SmolStr;
 
+use super::families::Families;
+
 pub type StringField = SmolStr;
 
 #[derive(Debug, Clone, Default)]
 pub struct Frame {
     pub category: Option<StringField>,
-    pub family: Option<StringField>,
+    pub family: Families,
     pub function: Option<StringField>,
     pub module: Option<StringField>,
     pub package: Option<StringField>,
@@ -20,7 +22,6 @@ pub struct Frame {
 #[derive(Debug, Clone, Copy)]
 pub enum FrameField {
     Category,
-    Family,
     Function,
     Module,
     Package,
@@ -31,7 +32,6 @@ impl fmt::Display for FrameField {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FrameField::Category => write!(f, "category"),
-            FrameField::Family => write!(f, "family"),
             FrameField::Function => write!(f, "function"),
             FrameField::Module => write!(f, "module"),
             FrameField::Package => write!(f, "package"),
@@ -44,7 +44,6 @@ impl Frame {
     pub fn get_field(&self, field: FrameField) -> Option<&StringField> {
         match field {
             FrameField::Category => self.category.as_ref(),
-            FrameField::Family => self.family.as_ref(),
             FrameField::Function => self.function.as_ref(),
             FrameField::Module => self.module.as_ref(),
             FrameField::Package => self.package.as_ref(),
@@ -59,11 +58,12 @@ impl Frame {
                 .pointer("/data/category")
                 .and_then(|s| s.as_str())
                 .map(SmolStr::new),
-            family: raw_frame
-                .get("platform")
-                .and_then(|s| s.as_str())
-                .or(Some(platform))
-                .map(SmolStr::new),
+            family: Families::new(
+                raw_frame
+                    .get("platform")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or(platform),
+            ),
             function: raw_frame
                 .get("function")
                 .and_then(|s| s.as_str())

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -3,17 +3,17 @@ use smol_str::SmolStr;
 mod actions;
 mod cache;
 mod config_structure;
+mod families;
 mod frame;
 mod grammar;
 mod matchers;
 mod rules;
 
-use crate::enhancers::config_structure::{EncodedAction, EncodedMatcher};
-
-use self::config_structure::EncodedEnhancements;
-pub use self::frame::{Frame, StringField};
-pub use self::rules::Rule;
 pub use cache::*;
+use config_structure::{EncodedAction, EncodedEnhancements, EncodedMatcher};
+pub use families::Families;
+pub use frame::{Frame, StringField};
+pub use rules::Rule;
 
 #[derive(Debug, Clone, Default)]
 pub struct ExceptionData {


### PR DESCRIPTION
I believe the `families` check is hot enough to warrant such a micro-optimization.

```
enhancers                          fastest       │ slowest       │ median        │ mean
# before:
├─ apply_modifications             416.3 µs      │ 1.21 ms       │ 464.4 µs      │ 489.2 µs
# after:
├─ apply_modifications             376.9 µs      │ 1.803 ms      │ 412.3 µs      │ 444.9 µs
```

Looks like a ~10% improvement, so why not :-)