### PR TITLE
Make cache methods non-generic

### DIFF
--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -58,7 +58,7 @@ impl Enhancements {
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
-            let rule = cache.get_or_try_insert_rule(line, grammar::parse_rule)?;
+            let rule = cache.get_or_try_insert_rule(line)?;
             all_rules.push(rule);
         }
 


### PR DESCRIPTION
The `get_or_try_insert` methods on `Cache` were only ever called with one function argument each (as obviously must be the case for consistency reasons). Therefore we just bake those function arguments in directly.