### PR TITLE
Fix tracking of which rule last updated in_app

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -90,7 +90,7 @@ impl Enhancements {
                     path: frame.path.0,
 
                     in_app: frame.in_app,
-                    orig_in_app: frame.in_app,
+                    in_app_last_changed: None,
                 };
                 Ok(frame)
             })

--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -16,7 +16,6 @@ pub struct Frame {
     pub path: Option<StringField>,
 
     pub in_app: Option<bool>,
-    pub orig_in_app: Option<bool>,
     pub in_app_last_changed: Option<Rule>,
 }
 
@@ -75,8 +74,6 @@ impl Frame {
                 .get("module")
                 .and_then(|s| s.as_str())
                 .map(SmolStr::new),
-
-            orig_in_app: None,
 
             package: raw_frame
                 .get("package")

--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use smol_str::SmolStr;
 
-use super::families::Families;
+use super::{families::Families, Rule};
 
 pub type StringField = SmolStr;
 
@@ -17,6 +17,7 @@ pub struct Frame {
 
     pub in_app: Option<bool>,
     pub orig_in_app: Option<bool>,
+    pub in_app_last_changed: Option<Rule>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -87,6 +88,7 @@ impl Frame {
                 .or(raw_frame.get("filename"))
                 .and_then(|s| s.as_str())
                 .map(|s| SmolStr::new(s.replace('\\', "/").to_lowercase())),
+            in_app_last_changed: None,
         }
     }
 }

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -121,11 +121,25 @@ impl Enhancements {
     ) -> StacktraceState {
         let mut stacktrace_state = StacktraceState::default();
 
+        // First, update the `in_app` hints. We have kept track of which rule last set the
+        // `in_app` field of each frame, so we don't need to iterate over the rules again for this.
+        for (component, frame) in components.iter_mut().zip(frames.iter()) {
+            if let Some(rule) = frame.in_app_last_changed.as_ref() {
+                // in_app is definitely set, otherwise `in_app_last_changed` would be `None`
+                let state = if frame.in_app.unwrap() {
+                    "in-app"
+                } else {
+                    "out of app"
+                };
+                component.hint = Some(format!("marked {state} by stack trace rule ({rule})"));
+            }
+        }
+
         // Apply direct frame actions and update the stack state alongside
         for rule in &self.updater_rules {
             for idx in 0..frames.len() {
                 if rule.matches_frame(frames, idx) {
-                    rule.update_frame_components_contributions(components, frames, idx);
+                    rule.update_frame_components_contributions(components, idx);
                     rule.modify_stacktrace_state(&mut stacktrace_state);
                 }
             }

--- a/rust/src/enhancers/rules.rs
+++ b/rust/src/enhancers/rules.rs
@@ -100,18 +100,13 @@ impl Rule {
     /// Applies all modifications from this rule's actions to matching frames.
     pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize) {
         for action in &self.0.actions {
-            action.apply_modifications_to_frame(frames, idx)
+            action.apply_modifications_to_frame(frames, idx, self)
         }
     }
 
-    pub fn update_frame_components_contributions(
-        &self,
-        components: &mut [Component],
-        frames: &[Frame],
-        idx: usize,
-    ) {
+    pub fn update_frame_components_contributions(&self, components: &mut [Component], idx: usize) {
         for action in &self.0.actions {
-            action.update_frame_components_contributions(components, frames, idx, self);
+            action.update_frame_components_contributions(components, idx, self);
         }
     }
 }


### PR DESCRIPTION
This reworks the logic for keeping track of which rule last set a frame's `in_app` flag. Instead of relying on the frankly incomprehensible `in_app_changed` function, we now save the rule in the frame every time the `in_app` flag is modified. Then we can simply iterate over the (frame, component) pairs in `Enhancements::update_frame_components_contributions` and set the hints based on the saved rule.

As a consequence, the `orig_in_app` field on `Frame` becomes unnecessary.