### PR TITLE
Add `mypy` to CI, along  with more python tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       # - run: make lint-python
 
   doc-comments:
-    name: Rust doc comments
+    name: Documentation
     runs-on: ubuntu-latest
     env:
       RUSTDOCFLAGS: -Dwarnings
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
 
-    name: Rust Test on ${{ matrix.os }}
+    name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -72,6 +72,7 @@ jobs:
 
       - run: make install-py-dev
       - run: pytest -vvs
+      - run: mypy
 
   codecov:
     name: Code Coverage

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ tests: test
 INDEX_URL=--index-url https://pypi.devinfra.sentry.io/simple
 
 install-python-dependencies:
-	pip uninstall -qqy uwsgi  # pip doesn't do well with swapping drop-ins
 	pip install $(INDEX_URL) -r requirements-build.txt
 	pip install $(INDEX_URL) -r requirements.txt
 	pip install $(INDEX_URL) -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,18 @@ dynamic = ["version"]
 [tool.maturin]
 manifest-path = "bindings/Cargo.toml"
 python-source = "python"
+
+[tool.mypy]
+python_version = "3.10"
+plugins = ["pydantic.mypy"]
+files = ["."]
+exclude = ["^.venv/"]
+
+[tool.black]
+line-length = 100
+target-version = ['py310']
+
+[tool.isort]
+profile = "black"
+line_length = 100
+lines_between_sections = 1

--- a/python/sentry_ophio/enhancers.pyi
+++ b/python/sentry_ophio/enhancers.pyi
@@ -1,4 +1,4 @@
-from typing import Iterator, Any
+from typing import Any, Iterator
 
 Frame = dict[str, Any]
 ModificationResult = tuple[str | None, bool | None]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@
 
 black==23.12.0
 flake8==6.1.0
+isort==5.13.2
 mypy==1.8.0
+pydantic==2.5.2
 pytest==7.4.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -1,6 +1,6 @@
 from typing import Any, Mapping, Optional, Sequence, Union
 
-from sentry_ophio.enhancers import Enhancements, Cache
+from sentry_ophio.enhancers import Cache, Enhancements
 
 # TODO: all this is copied from Sentry, and the Sentry side should still
 # be responsible for the `create_match_frame`
@@ -26,11 +26,7 @@ def get_path(data: PathSearchable, *path, **kwargs):
     for p in path:
         if isinstance(data, Mapping) and p in data:
             data = data[p]
-        elif (
-            isinstance(data, (list, tuple))
-            and isinstance(p, int)
-            and -len(data) <= p < len(data)
-        ):
+        elif isinstance(data, (list, tuple)) and isinstance(p, int) and -len(data) <= p < len(data):
             data = data[p]
         else:
             return default
@@ -77,7 +73,5 @@ def test_simple_enhancer():
     ]
     exception_data = {"ty": None, "value": None, "mechanism": None}
 
-    modified_frames = enhancer.apply_modifications_to_frames(
-        iter(frames), exception_data
-    )
+    modified_frames = enhancer.apply_modifications_to_frames(iter(frames), exception_data)
     print(modified_frames)


### PR DESCRIPTION
I used `isort` to sort all of the imports (not enforced in CI yet), as well as `black` to reformatted the test files. I haven’t enabled that in CI either, as it would currently reformatted all the `pyi` files as well in a way that makes them unreadable :-(