### PR TITLE
Rework python package/module exporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "ophio-bindings"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "proguard",
+ "pyo3",
+ "rust-ophio",
+ "smol_str",
+ "symbolic",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,18 +836,6 @@ name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
-
-[[package]]
-name = "sentry-ophio"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "proguard",
- "pyo3",
- "rust-ophio",
- "smol_str",
- "symbolic",
-]
 
 [[package]]
 name = "serde"

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "sentry-ophio"
+name = "ophio-bindings"
 version = "0.1.0"
 publish = false
 edition = "2021"
 
 [lib]
-name = "sentry_ophio"
+name = "_bindings"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -3,34 +3,12 @@ use pyo3::prelude::*;
 mod enhancers;
 mod proguard;
 
-macro_rules! add_module {
-    ($py:ident : $parent:ident . $name:ident) => {
-        // This uses the workaround from:
-        // https://github.com/PyO3/pyo3/issues/759#issuecomment-1811992321
-        // For the problem raised in https://pyo3.rs/v0.20.0/module#python-submodules
-        {
-            let module = PyModule::new($py, stringify!($name))?;
-            $parent.add_submodule(module)?;
-            let qualified_name = concat!("sentry_ophio.", stringify!($name));
-            $py.import("sys")?
-                .getattr("modules")?
-                .set_item(qualified_name, module)?;
-            module.setattr("__name__", qualified_name)?;
-            module
-        }
-    };
-}
-
-/// A Python module implemented in Rust.
 #[pymodule]
-fn sentry_ophio(py: Python, m: &PyModule) -> PyResult<()> {
-    let proguard_module = add_module!(py: m.proguard);
-    proguard_module.add_class::<proguard::JavaStackFrame>()?;
-    proguard_module.add_class::<proguard::ProguardMapper>()?;
-
-    let enhancers_module = add_module!(py: m.enhancers);
-    enhancers_module.add_class::<enhancers::Enhancements>()?;
-    enhancers_module.add_class::<enhancers::Cache>()?;
+fn _bindings(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<proguard::JavaStackFrame>()?;
+    m.add_class::<proguard::ProguardMapper>()?;
+    m.add_class::<enhancers::Enhancements>()?;
+    m.add_class::<enhancers::Cache>()?;
 
     Ok(())
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
 dynamic = ["version"]
 
 [tool.maturin]
+module-name = "sentry_ophio._bindings"
 manifest-path = "bindings/Cargo.toml"
 python-source = "python"
 

--- a/python/sentry_ophio/__init__.py
+++ b/python/sentry_ophio/__init__.py
@@ -1,1 +1,0 @@
-from .sentry_ophio import *

--- a/python/sentry_ophio/enhancers.py
+++ b/python/sentry_ophio/enhancers.py
@@ -1,1 +1,4 @@
 from ._bindings import Cache, Enhancements
+
+Cache.__module__ = __name__
+Enhancements.__module__ = __name__

--- a/python/sentry_ophio/enhancers.py
+++ b/python/sentry_ophio/enhancers.py
@@ -1,0 +1,1 @@
+from ._bindings import Cache, Enhancements

--- a/python/sentry_ophio/proguard.py
+++ b/python/sentry_ophio/proguard.py
@@ -1,0 +1,1 @@
+from ._bindings import JavaStackFrame, ProguardMapper

--- a/python/sentry_ophio/proguard.py
+++ b/python/sentry_ophio/proguard.py
@@ -1,1 +1,4 @@
 from ._bindings import JavaStackFrame, ProguardMapper
+
+JavaStackFrame.__module__ = __name__
+ProguardMapper.__module__ = __name__


### PR DESCRIPTION
I believe I understand the problem with packages/modules now.

A python *package* is a directory with a `__init__.py`, and a *module* is just a python file.

When writing `import`s in Python, the *parent* of that path *must* be a package.

So `from this_is_a_package.this_is_a_module import *` works. Whereas `from this_is_a_parent_module.this_is_a_child_module import *` does not.

However it would seem that one limitation of python extension modules is that they are in fact *modules*, and not *packages*. So you cannot *directly* import stuff from their sub-modules.

Long story short, the workaround I found online was manipulating the global `sys.modules` directory to make this work, however that messes with tools like `Pylance` in VS Code.

Instead, I now just export a flat list of classes (and maybe functions in the future) from the `_bindings`, and use python code to reexport things as targeted sub-modules.

---

TBH, we might as well just skip this and just export everything directly without splitting things into sub-modules, but IMO having submodules makes sense for consumers, especially if we continue adding more functionality.