### PR TITLE
Fix glob pattern case sensitivity

### DIFF
--- a/rust/src/enhancers/cache.rs
+++ b/rust/src/enhancers/cache.rs
@@ -72,7 +72,7 @@ fn translate_pattern(pat: &str, is_path_matcher: bool) -> anyhow::Result<Regex> 
     };
     let mut builder = GlobBuilder::new(&pat);
     builder.literal_separator(is_path_matcher);
-    builder.case_insensitive(true);
+    builder.case_insensitive(is_path_matcher);
     let glob = builder.build()?;
     Ok(RegexBuilder::new(glob.regex()).build()?)
 }


### PR DESCRIPTION
[According to the docs](https://docs.sentry.io/product/data-management-settings/event-grouping/stack-trace-rules/#matchers), `function` and `module are supposed to match case-sensitively, and `path` and `package` are supposed to match case-insensitively. Fortunately, this neatly lines up with whether the match is path-like.