### PR TITLE
Downgrade Python requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ For this reason, one can just increment the minor version for every new release 
 - Manually trigger the [`Release workflow`](actions/workflows/release.yml)
 - This should ideally auto-approve the publish, publish to `pypi` and then uplift that to our
   internal `pypi` mirror as well.
-- If the publish fails, which it unfortunately does way too often, search for a soundproof booth
-  and scream from the top of your lungs, then go to `#z-vent` and complain loudly about
-  the broken publishes and that we can’t have nice things.
+- If the publish fails, which it unfortunately does way too often, just bump the patch version and try again.
 
 ## Repo Structure
 

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -15,7 +15,7 @@ pyo3 = { version = "0.20.0", features = [
     "anyhow",
     "extension-module",
     "serde",
-    "abi3-py310",
+    "abi3-py39",
 ] }
 rust-ophio = { path = "../rust" }
 smol_str = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "sentry_ophio"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Turns out we are developing locally and testing with 3.10, but actually target 3.9:
https://github.com/getsentry/pypi/issues/623

So lets downgrade here as well so that we can publish and uplift automatically.