### PR TITLE
Ignore Broken Glob matchers

### DIFF
--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -177,3 +177,23 @@ pub fn parse_rule(input: &str) -> anyhow::Result<Rule> {
 
     Ok(Rule::new(matchers, actions))
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::enhancers::Frame;
+
+    use super::*;
+
+    #[test]
+    fn parse_objc_matcher() {
+        let rule = parse_rule("stack.function:-[* -app").unwrap();
+
+        let frames = &[Frame::from_test(
+            &json!({"function": "-[UIApplication sendAction:to:from:forEvent:] "}),
+            "native",
+        )];
+        assert!(!rule.matches_frame(frames, 0));
+    }
+}

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -182,6 +182,7 @@ pub fn parse_rule(input: &str) -> anyhow::Result<Rule> {
 mod tests {
     use serde_json::json;
 
+    use crate::enhancers::config_structure::EncodedMatcher;
     use crate::enhancers::Frame;
 
     use super::*;
@@ -195,5 +196,14 @@ mod tests {
             "native",
         )];
         assert!(!rule.matches_frame(frames, 0));
+
+        let matcher: EncodedMatcher = serde_json::from_str(r#""f-[*""#).unwrap();
+        let matcher = matcher.into_matcher(&mut Default::default()).unwrap();
+        match matcher {
+            Matcher::Frame(frame) => {
+                assert!(!frame.matches_frame(frames, 0));
+            }
+            Matcher::Exception(_) => unreachable!(),
+        }
     }
 }


### PR DESCRIPTION
This would in theory fix https://sentry.sentry.io/issues/4934804272/ in the sense that we keep the current behavior.

Although the current behavior is to silently ignore the rule and always assume it does not match, which happens here:
https://github.com/getsentry/relay/blob/e9a7e18983c699fc6bc9024e49190a8e8c678c8c/relay-common/src/glob.rs#L62-L67

I’m not really happy with this solution, as the grammar accepts the matcher, but the matcher itself silently fails all the time :-(