### PR TITLE
ref: Improve enhancers parse errors

### DIFF
--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -14,7 +14,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_while1};
 use nom::character::complete::{anychar, char, space0};
 use nom::combinator::{all_consuming, cut, map, map_res, opt, value};
-use nom::error::{context, ErrorKind, VerboseError};
+use nom::error::{context, ErrorKind};
 use nom::multi::{many0, many1};
 use nom::sequence::{delimited, preceded, tuple};
 use nom::{Finish, IResult, Parser};
@@ -252,26 +252,4 @@ pub fn parse_rule(input: &str) -> anyhow::Result<Rule> {
             .map_err(|e| anyhow::Error::msg(dbg!(e).to_string()))?;
 
     Ok(Rule::new(matchers, actions))
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::json;
-
-    use crate::enhancers::Frame;
-
-    use super::*;
-
-    #[test]
-    fn parse_objc_matcher() {
-        let rule = parse_rule(r#"stack.function:-[* -app"#).unwrap_err();
-
-        println!("{rule:?}");
-
-        // let frames = &[Frame::from_test(
-        //     &json!({"function": "-[UIApplication sendAction:to:from:forEvent:] "}),
-        //     "native",
-        // )];
-        // assert!(!rule.matches_frame(frames, 0));
-    }
 }

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -8,10 +8,13 @@
 // - we should probably support better Error handling
 // - quoted identifiers/arguments should properly support escapes, etc
 
+use std::fmt;
+
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_while1};
 use nom::character::complete::{anychar, char, space0};
-use nom::combinator::{all_consuming, map, map_res, opt, value};
+use nom::combinator::{all_consuming, cut, map, map_res, opt, value};
+use nom::error::{context, ErrorKind, VerboseError};
 use nom::multi::{many0, many1};
 use nom::sequence::{delimited, preceded, tuple};
 use nom::{Finish, IResult, Parser};
@@ -22,24 +25,83 @@ use super::matchers::{FrameOffset, Matcher};
 use super::rules::Rule;
 use super::Cache;
 
-fn ident(input: &str) -> IResult<&str, &str> {
+#[derive(Debug)]
+enum ParseErrorKind {
+    Char(char),
+    Nom(ErrorKind),
+    External(anyhow::Error),
+    Context(&'static str),
+}
+
+#[derive(Debug)]
+struct ParseError<'a>(Vec<(&'a str, ParseErrorKind)>);
+
+impl<'a> nom::error::ParseError<&'a str> for ParseError<'a> {
+    fn from_error_kind(input: &'a str, kind: ErrorKind) -> Self {
+        Self(vec![(input, ParseErrorKind::Nom(kind))])
+    }
+
+    fn append(input: &'a str, kind: ErrorKind, mut other: Self) -> Self {
+        other.0.push((input, ParseErrorKind::Nom(kind)));
+        other
+    }
+
+    fn from_char(input: &'a str, c: char) -> Self {
+        Self(vec![(input, ParseErrorKind::Char(c))])
+    }
+}
+
+impl<'a> nom::error::ContextError<&'a str> for ParseError<'a> {
+    fn add_context(input: &'a str, ctx: &'static str, mut other: Self) -> Self {
+        other.0.push((input, ParseErrorKind::Context(ctx)));
+        other
+    }
+}
+
+impl<'a> nom::error::FromExternalError<&'a str, anyhow::Error> for ParseError<'a> {
+    fn from_external_error(input: &'a str, _kind: ErrorKind, e: anyhow::Error) -> Self {
+        Self(vec![(input, ParseErrorKind::External(e))])
+    }
+}
+
+impl fmt::Display for ParseError<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Parse error:")?;
+        for (input, error) in &self.0 {
+            match error {
+                ParseErrorKind::Nom(e) => writeln!(f, "{e:?} at: {input}")?,
+                ParseErrorKind::Char(c) => writeln!(f, "expected '{c}' at: {input}")?,
+                ParseErrorKind::Context(s) => writeln!(f, "in section '{s}', at: {input}")?,
+                ParseErrorKind::External(e) => writeln!(f, "{e}")?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for ParseError<'_> {}
+
+type ParseResult<'a, T> = IResult<&'a str, T, ParseError<'a>>;
+
+fn ident(input: &str) -> ParseResult<&str> {
     take_while1(|c: char| c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-'))(input)
 }
 
-fn rule_bool(input: &str) -> IResult<&str, bool> {
+fn rule_bool(input: &str) -> ParseResult<bool> {
     alt((
         value(true, alt((tag("1"), tag("yes"), tag("true")))),
         value(false, alt((tag("0"), tag("no"), tag("false")))),
     ))(input)
 }
 
-fn rule_number(input: &str) -> IResult<&str, usize> {
+fn rule_number(input: &str) -> ParseResult<usize> {
     map(take_while1(|c: char| c.is_ascii_digit()), |n: &str| {
         n.parse().unwrap()
     })(input)
 }
 
-fn frame_matcher(frame_offset: FrameOffset) -> impl Fn(&str) -> IResult<&str, Matcher> {
+fn frame_matcher(frame_offset: FrameOffset) -> impl Fn(&str) -> ParseResult<Matcher> {
     move |input| {
         let input = input.trim_start();
 
@@ -50,12 +112,12 @@ fn frame_matcher(frame_offset: FrameOffset) -> impl Fn(&str) -> IResult<&str, Ma
             }),
             char('"'),
         );
-        let matcher_type = alt((ident, quoted_ident));
+        let matcher_type = context("matcher type", alt((ident, quoted_ident)));
 
         let unquoted = take_while1(|c: char| !c.is_ascii_whitespace());
         // TODO: escapes, etc
         let quoted = delimited(char('"'), take_while1(|c: char| c != '"'), char('"'));
-        let argument = alt((quoted, unquoted));
+        let argument = context("matcher argument", alt((quoted, unquoted)));
 
         let mut matcher = map_res(
             tuple((opt(char('!')), matcher_type, char(':'), argument)),
@@ -76,33 +138,39 @@ fn frame_matcher(frame_offset: FrameOffset) -> impl Fn(&str) -> IResult<&str, Ma
     }
 }
 
-fn matchers(input: &str) -> IResult<&str, Vec<Matcher>> {
+fn matchers(input: &str) -> ParseResult<Vec<Matcher>> {
     let input = input.trim_start();
 
-    let caller_matcher = tuple((
-        space0,
-        char('['),
-        space0,
-        frame_matcher(FrameOffset::Caller),
-        space0,
-        char(']'),
-        space0,
-        char('|'),
-    ));
-    let callee_matcher = tuple((
-        space0,
-        char('|'),
-        space0,
-        char('['),
-        space0,
-        frame_matcher(FrameOffset::Callee),
-        space0,
-        char(']'),
-    ));
+    let caller_matcher = context(
+        "caller matcher",
+        tuple((
+            space0,
+            char('['),
+            space0,
+            cut(frame_matcher(FrameOffset::Caller)),
+            space0,
+            char(']'),
+            space0,
+            char('|'),
+        )),
+    );
+    let callee_matcher = context(
+        "callee matcher",
+        tuple((
+            space0,
+            char('|'),
+            space0,
+            char('['),
+            space0,
+            cut(frame_matcher(FrameOffset::Callee)),
+            space0,
+            char(']'),
+        )),
+    );
 
     let mut matchers = tuple((
         opt(caller_matcher),
-        many1(frame_matcher(FrameOffset::None)),
+        context("matchers", many1(frame_matcher(FrameOffset::None))),
         opt(callee_matcher),
     ));
 
@@ -119,7 +187,7 @@ fn matchers(input: &str) -> IResult<&str, Vec<Matcher>> {
     Ok((input, matchers))
 }
 
-fn actions(input: &str) -> IResult<&str, Vec<Action>> {
+fn actions(input: &str) -> ParseResult<Vec<Action>> {
     let max_frames = preceded(
         tuple((tag("max-frames"), space0, char('='), space0)),
         rule_number,
@@ -141,7 +209,10 @@ fn actions(input: &str) -> IResult<&str, Vec<Action>> {
     let category = preceded(tuple((tag("category"), space0, char('='), space0)), ident)
         .map(|c| VarAction::Category(SmolStr::new(c)));
 
-    let var_action = alt((max_frames, min_frames, invert_stacktrace, category));
+    let var_action = context(
+        "var action",
+        alt((max_frames, min_frames, invert_stacktrace, category)),
+    );
 
     let flag_name = alt((
         value(FlagActionType::Group, tag("group")),
@@ -154,12 +225,17 @@ fn actions(input: &str) -> IResult<&str, Vec<Action>> {
         value(Range::Down, char('v')),
     )));
     let flag = alt((value(true, char('+')), value(false, char('-'))));
-    let flag_action =
-        tuple((range, flag, flag_name)).map(|(range, flag, ty)| FlagAction { range, flag, ty });
+    let flag_action = context(
+        "flag action",
+        tuple((range, flag, flag_name)).map(|(range, flag, ty)| FlagAction { range, flag, ty }),
+    );
 
-    let action = preceded(
-        space0,
-        alt((map(flag_action, Action::Flag), map(var_action, Action::Var))),
+    let action = context(
+        "action",
+        preceded(
+            space0,
+            alt((map(flag_action, Action::Flag), map(var_action, Action::Var))),
+        ),
     );
 
     let (input, actions) = many1(action)(input)?;
@@ -173,7 +249,29 @@ pub fn parse_rule(input: &str) -> anyhow::Result<Rule> {
     let (_input, (matchers, actions, _)) =
         all_consuming(tuple((matchers, actions, opt(comment))))(input)
             .finish()
-            .map_err(|e| anyhow::Error::msg(e.to_string()))?;
+            .map_err(|e| anyhow::Error::msg(dbg!(e).to_string()))?;
 
     Ok(Rule::new(matchers, actions))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::enhancers::Frame;
+
+    use super::*;
+
+    #[test]
+    fn parse_objc_matcher() {
+        let rule = parse_rule(r#"stack.function:-[* -app"#).unwrap_err();
+
+        println!("{rule:?}");
+
+        // let frames = &[Frame::from_test(
+        //     &json!({"function": "-[UIApplication sendAction:to:from:forEvent:] "}),
+        //     "native",
+        // )];
+        // assert!(!rule.matches_frame(frames, 0));
+    }
 }


### PR DESCRIPTION
This improves the errors reported by the enhancers parser. In particular, for the malformed example in https://github.com/getsentry/ophio/pull/38 you now get
```
Parse error:
error parsing glob '-[*': unclosed character class; missing ']'
Many1 at: stack.function:-[* -app
in section 'matchers', at: stack.function:-[* -app
```
Unfortunately this requires quite a bit of machinery and a sort-of reimplementation of `nom`'s `VerboseError` (which doesn't allow wrapping external errors).