### PR TITLE
ref(enhancers): Replace nom parser with handwritten recursive descent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,29 +103,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown",
- "stacker",
-]
 
 [[package]]
 name = "clap"
@@ -612,15 +593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "pyo3"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,11 +746,9 @@ name = "rust-ophio"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "chumsky",
  "divan",
  "globset",
  "lru",
- "nom",
  "regex",
  "rmp-serde",
  "serde",
@@ -900,19 +870,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
-]
 
 [[package]]
 name = "string_cache"
@@ -1091,28 +1048,6 @@ dependencies = [
  "leb128",
  "thiserror",
 ]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,10 +9,8 @@ testing = ["dep:serde_json"]
 
 [dependencies]
 anyhow = "1.0.79"
-chumsky = "0.9.3"
 globset = "0.4.14"
 lru = "0.12.1"
-nom = "7.1.3"
 regex = "1.10.2"
 rmp-serde = "1.1.2"
 serde = { version = "1.0.195", features = ["derive"] }

--- a/rust/src/enhancers/cache.rs
+++ b/rust/src/enhancers/cache.rs
@@ -29,7 +29,7 @@ impl RegexCache {
             Some(cache) => {
                 let key = (key.into(), is_path);
                 if let Some(regex) = cache.get(&key) {
-                    return Ok(regex.clone());
+                    return Ok(Arc::clone(regex));
                 }
 
                 let regex = translate_pattern(&key.0, key.1).map(Arc::new)?;

--- a/rust/src/enhancers/cache.rs
+++ b/rust/src/enhancers/cache.rs
@@ -9,6 +9,7 @@ use smol_str::SmolStr;
 
 use super::{grammar::parse_rule, rules::Rule};
 
+/// An LRU cache for memoizing regex construction.
 #[derive(Debug, Default)]
 pub struct RegexCache(Option<LruCache<(SmolStr, bool), Arc<Regex>>>);
 
@@ -40,6 +41,8 @@ impl RegexCache {
     }
 }
 
+/// A cache for memoizing the parsing of [`Rules`](Rule) from their string
+/// representations.
 #[derive(Debug, Default)]
 pub struct RulesCache(Option<LruCache<SmolStr, Rule>>);
 

--- a/rust/src/enhancers/config_structure.rs
+++ b/rust/src/enhancers/config_structure.rs
@@ -6,7 +6,7 @@ use smol_str::SmolStr;
 
 use super::actions::{Action, FlagAction, FlagActionType, Range, VarAction};
 use super::matchers::{FrameOffset, Matcher};
-use super::Cache;
+use super::RegexCache;
 
 /// Compact representation of an [`Enhancements`](super::Enhancements) structure.
 ///
@@ -37,7 +37,7 @@ impl<'a> EncodedMatcher<'a> {
     /// Converts the encoded matcher to a [`Matcher`].
     ///
     /// The `cache` is used to memoize the computation of regexes.
-    pub fn into_matcher(self, cache: &mut Cache) -> anyhow::Result<Matcher> {
+    pub fn into_matcher(self, regex_cache: &mut RegexCache) -> anyhow::Result<Matcher> {
         let mut def = self.0;
         let mut frame_offset = FrameOffset::None;
 
@@ -83,7 +83,7 @@ impl<'a> EncodedMatcher<'a> {
             }
         };
 
-        Matcher::new(negated, key, arg, frame_offset, cache)
+        Matcher::new(negated, key, arg, frame_offset, regex_cache)
     }
 }
 

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -266,8 +266,10 @@ fn matchers<'a>(
 }
 
 pub fn parse_rule(input: &str, regex_cache: &mut RegexCache) -> anyhow::Result<Rule> {
-    let (matchers, after_matchers) = matchers(input, regex_cache)?;
-    let actions = actions(after_matchers)?;
+    let (matchers, after_matchers) = matchers(input, regex_cache)
+        .with_context(|| format!("at `{input}`: failed to parse matchers"))?;
+    let actions = actions(after_matchers)
+        .with_context(|| format!("at `{after_matchers}`: failed to parse actions"))?;
 
     Ok(Rule::new(matchers, actions))
 }

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -15,6 +15,26 @@ use super::matchers::{FrameOffset, Matcher};
 use super::rules::Rule;
 use super::RegexCache;
 
+/// Possible prefixes of a matcher definition.
+/// Matchers always start with one of these,
+/// and actions never do. This means that if
+/// the rest of the input starts with one these,
+/// there is another matcher to parse, and if it doesn't,
+/// there isn't.
+const MATCHER_LOOKAHEAD: [&str; 11] = [
+    "!",
+    "a",
+    "category:",
+    "e",
+    "f",
+    "me",
+    "mo",
+    "p",
+    "s",
+    "t",
+    "va",
+];
+
 /// Strips the prefix `pat` from `input` and returns the rest.
 ///
 /// Returns an error if `input` doesn't start with `pat.`
@@ -289,26 +309,6 @@ fn matchers<'a>(
 
     // Keep track of whether we've parsed at least one matcher
     let mut parsed = false;
-
-    // Possible prefixes of a matcher definition.
-    // Matchers always start with one of these,
-    // and actions never do. This means that if
-    // the rest of the input starts with one these,
-    // there is another matcher to parse, and if it doesn't,
-    // there isn't.
-    const MATCHER_LOOKAHEAD: [&str; 11] = [
-        "!",
-        "a",
-        "category:",
-        "e",
-        "f",
-        "me",
-        "mo",
-        "p",
-        "s",
-        "t",
-        "va",
-    ];
 
     while MATCHER_LOOKAHEAD
         .iter()

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -103,7 +103,7 @@ impl Enhancements {
             .map(|r| {
                 let matchers =
                     r.0.into_iter()
-                        .map(|encoded| EncodedMatcher::into_matcher(encoded, cache))
+                        .map(|encoded| EncodedMatcher::into_matcher(encoded, &mut cache.regex))
                         .collect::<anyhow::Result<_>>()?;
                 let actions =
                     r.1.into_iter()


### PR DESCRIPTION
Or at least mostly recursive.

I got very annoyed at the bad error messages in the `nom` parser, so I wrote an RD parser by hand. It uses `anyhow` for errors and as a consequence, they are pretty nice. Performance is, in my tests, pretty much exactly the same as before.

I think it's a matter of taste which version is more readable; this one also isn't documented at all yet.

The first commit is a version that mutates the input instead of returning a new slice every time. I haven't decided yet which I like better.

Additionally, caches have been split up; this is because passing the entire cache to the parser for regex parsing purposes would otherwise lead to ownership problems. Interestingly, at least in the benchmark it doesn't matter if we cache regex creation in the parser—the rule caching subsumes it entirely.