### PR TITLE
Silently accept invalid `app` matcher

### DIFF
--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -46,6 +46,8 @@ pub enum FrameField {
     Module,
     Package,
     Path,
+    // NOTE: This is only used to have something to `Display` in the `Noop` matcher.
+    App,
 }
 
 impl fmt::Display for FrameField {
@@ -56,6 +58,7 @@ impl fmt::Display for FrameField {
             FrameField::Module => write!(f, "module"),
             FrameField::Package => write!(f, "package"),
             FrameField::Path => write!(f, "path"),
+            FrameField::App => write!(f, "app"),
         }
     }
 }
@@ -69,6 +72,8 @@ impl Frame {
             FrameField::Module => self.module.as_ref(),
             FrameField::Package => self.package.as_ref(),
             FrameField::Path => self.path.as_ref(),
+            // NOTE: we never *access* the field via `get_field`.
+            FrameField::App => unreachable!(),
         }
     }
 

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -205,5 +205,21 @@ mod tests {
             }
             Matcher::Exception(_) => unreachable!(),
         }
+
+        let _rule = parse_rule("stack.module:[foo:bar/* -app").unwrap();
+    }
+
+    #[test]
+    fn invalid_app_matcher() {
+        let rule = parse_rule("app://../../src/some-file.ts -group -app").unwrap();
+
+        let frames = &[
+            Frame::from_test(&json!({}), "native"),
+            Frame::from_test(&json!({"in_app": true}), "native"),
+            Frame::from_test(&json!({"in_app": false}), "native"),
+        ];
+        assert!(!rule.matches_frame(frames, 0));
+        assert!(!rule.matches_frame(frames, 1));
+        assert!(!rule.matches_frame(frames, 2));
     }
 }

--- a/rust/src/enhancers/matchers.rs
+++ b/rust/src/enhancers/matchers.rs
@@ -252,6 +252,7 @@ impl FrameMatcherInner {
         cache: &mut Cache,
     ) -> anyhow::Result<Self> {
         let Ok(pattern) = cache.get_or_try_insert_regex(pattern, path_like) else {
+            // TODO: we should be returning real errors in a `strict` parsing mode
             return Ok(Self::Noop { field });
         };
 
@@ -274,7 +275,11 @@ impl FrameMatcherInner {
         match expected {
             "1" | "true" | "yes" => Ok(Self::InApp { expected: true }),
             "0" | "false" | "no" => Ok(Self::InApp { expected: false }),
-            _ => Err(anyhow::anyhow!("Invalid value for `app`: `{expected}`")),
+            _ => Ok(Self::Noop {
+                field: FrameField::App,
+            }),
+            // TODO: we should be returning real errors in a `strict` parsing mode
+            // _ => Err(anyhow::anyhow!("Invalid value for `app`: `{expected}`")),
         }
     }
 


### PR DESCRIPTION
Similar to #38, the Python parser accepts more invalid things that just won’t ever match.
This is another one of those cases.