### PR TITLE
Switch to new PyO3 `Bound` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "5d0c41d899f822e5f39186d6da130a822a0a43edb19992b51bf4ef6cd0b4cfd1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "5509c2aa78c7e770077e41ba86f806e60dcee812e924ccb2d6fe78c0a0128ce2"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "e6bb234a86ed619a661f3bb3c2493aaff9cb937e33e198d17f5f20a15881e155"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "f0b787de2c6832eb1eb393c9f82f976a5a87bda979780d9b853878846a8d2e4b"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.0-beta.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "5e3b7beed357786d2afe845871964e824ad8af0df38a403f7d01cdc81aadb211"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1.0.79"
 proguard = { version = "5.4.0", features = ["uuid"] }
-pyo3 = { version = "0.20.0", features = [
+pyo3 = { version = "0.21.0-beta.0", features = [
     "anyhow",
     "extension-module",
     "serde",

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -4,7 +4,7 @@ mod enhancers;
 mod proguard;
 
 #[pymodule]
-fn _bindings(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _bindings(_py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<enhancers::Cache>()?;
     m.add_class::<enhancers::Component>()?;
     m.add_class::<enhancers::Enhancements>()?;

--- a/bindings/src/proguard.rs
+++ b/bindings/src/proguard.rs
@@ -45,12 +45,14 @@ impl ProguardMapper {
 
     /// Returns the UUID of the file.
     #[getter]
-    pub fn uuid<'p>(&self, py: Python<'p>) -> PyResult<&'p PyAny> {
+    pub fn uuid<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let uuid = self.inner.get().mapping.uuid();
 
-        let bytes = PyBytes::new(py, uuid.as_bytes());
-        let kwargs = [("bytes", bytes)].into_py_dict(py);
-        py.import("uuid")?.getattr("UUID")?.call((), Some(kwargs))
+        let bytes = PyBytes::new_bound(py, uuid.as_bytes());
+        let kwargs = [("bytes", bytes)].into_py_dict_bound(py);
+        py.import_bound("uuid")?
+            .getattr("UUID")?
+            .call((), Some(&kwargs))
     }
 
     /// True if the file contains line information.

--- a/python/sentry_ophio/enhancers.pyi
+++ b/python/sentry_ophio/enhancers.pyi
@@ -55,7 +55,7 @@ class Enhancements:
         """
     def apply_modifications_to_frames(
         self,
-        frames: Iterator[Frame],
+        frames: list[Frame],
         exception_data: dict[str, str | None],
     ) -> list[ModificationResult]:
         """
@@ -69,7 +69,7 @@ class Enhancements:
                                fields are "ty", "value", and "mechanism".
         """
     def update_frame_components_contributions(
-        self, frames: Iterator[Frame], components: list[Component]
+        self, frames: list[Frame], components: list[Component]
     ) -> StacktraceState:
         """
         Modifies a list of `Component`s according to the rules in this Enhancements object.

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -74,7 +74,7 @@ def test_simple_enhancer():
     ]
     exception_data = {"ty": None, "value": None, "mechanism": None}
 
-    modified_frames = enhancer.apply_modifications_to_frames(iter(frames), exception_data)
+    modified_frames = enhancer.apply_modifications_to_frames(frames, exception_data)
     print(modified_frames)
 
 
@@ -89,7 +89,7 @@ def test_sentinel_and_prefix(action, type):
 
     assert not getattr(components[0], f"is_{type}_frame")
 
-    enhancer.update_frame_components_contributions(iter(frames), components)
+    enhancer.update_frame_components_contributions(frames, components)
 
     expected = action == "+"
     assert getattr(components[0], f"is_{type}_frame") is expected


### PR DESCRIPTION
This opts into the new PyO3 0.21 beta, which is scheduled for a release this month.

It also switcher to the new `Bound` API which should be more performant.

Also switches from using an `Iterator` for the `match_frame`s to a `List`, as I hope that will be slightly more performant.