### PR TITLE
Add the complete `assemble_stacktrace_component` logic

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -32,11 +32,11 @@ impl FromPyObject<'_> for OptStr {
 }
 
 #[pyclass]
-pub struct StacktraceState {
+pub struct AssembleResult {
     #[pyo3(get)]
-    max_frames: usize,
+    contributes: Option<bool>,
     #[pyo3(get)]
-    min_frames: usize,
+    hint: Option<String>,
     #[pyo3(get)]
     invert_stacktrace: bool,
 }
@@ -44,7 +44,7 @@ pub struct StacktraceState {
 #[pyclass]
 pub struct Component {
     #[pyo3(get, set)]
-    contributes: bool,
+    contributes: Option<bool>,
     #[pyo3(get, set)]
     is_prefix_frame: bool,
     #[pyo3(get, set)]
@@ -56,7 +56,7 @@ pub struct Component {
 #[pymethods]
 impl Component {
     #[new]
-    fn new(contributes: bool, is_prefix_frame: bool, is_sentinel_frame: bool) -> Self {
+    fn new(is_prefix_frame: bool, is_sentinel_frame: bool, contributes: Option<bool>) -> Self {
         Self {
             contributes,
             is_prefix_frame,
@@ -139,23 +139,31 @@ impl Enhancements {
         Ok(result)
     }
 
-    fn update_frame_components_contributions(
+    fn assemble_stacktrace_component(
         &self,
         frames: Bound<'_, PyList>,
+        exception_data: ExceptionData,
         mut grouping_components: Vec<PyRefMut<Component>>,
-    ) -> PyResult<StacktraceState> {
+    ) -> PyResult<AssembleResult> {
         let frames: Vec<_> = frames
             .into_iter()
             .map(convert_frame_from_py)
             .collect::<PyResult<_>>()?;
+
+        let exception_data = enhancers::ExceptionData {
+            ty: exception_data.ty.0,
+            value: exception_data.value.0,
+            mechanism: exception_data.mechanism.0,
+        };
+
         let mut components: Vec<_> = grouping_components
             .iter()
             .map(|c| convert_component_from_py(c))
             .collect();
 
-        let stacktrace_state = self
-            .0
-            .update_frame_components_contributions(&mut components, &frames);
+        let assemble_result =
+            self.0
+                .assemble_stacktrace_component(&mut components, &frames, &exception_data);
 
         for (py_component, rust_component) in
             grouping_components.iter_mut().zip(components.into_iter())
@@ -166,10 +174,10 @@ impl Enhancements {
             py_component.hint = rust_component.hint;
         }
 
-        Ok(StacktraceState {
-            max_frames: stacktrace_state.max_frames.value,
-            min_frames: stacktrace_state.min_frames.value,
-            invert_stacktrace: stacktrace_state.invert_stacktrace.value,
+        Ok(AssembleResult {
+            contributes: assemble_result.contributes,
+            hint: assemble_result.hint,
+            invert_stacktrace: assemble_result.invert_stacktrace,
         })
     }
 }

--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -34,7 +34,7 @@ impl FromPyObject<'_> for OptStr {
 #[pyclass]
 pub struct AssembleResult {
     #[pyo3(get)]
-    contributes: Option<bool>,
+    contributes: bool,
     #[pyo3(get)]
     hint: Option<String>,
     #[pyo3(get)]

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -8,7 +8,7 @@ fn _bindings(_py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<enhancers::Cache>()?;
     m.add_class::<enhancers::Component>()?;
     m.add_class::<enhancers::Enhancements>()?;
-    m.add_class::<enhancers::StacktraceState>()?;
+    m.add_class::<enhancers::AssembleResult>()?;
     m.add_class::<proguard::JavaStackFrame>()?;
     m.add_class::<proguard::ProguardMapper>()?;
 

--- a/python/sentry_ophio/enhancers.py
+++ b/python/sentry_ophio/enhancers.py
@@ -1,6 +1,6 @@
-from ._bindings import Cache, Component, Enhancements, StacktraceState
+from ._bindings import AssembleResult, Cache, Component, Enhancements
 
+AssembleResult.__module__ = __name__
 Cache.__module__ = __name__
 Component.__module__ = __name__
 Enhancements.__module__ = __name__
-StacktraceState.__module__ = __name__

--- a/python/sentry_ophio/enhancers.pyi
+++ b/python/sentry_ophio/enhancers.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterator
+from typing import Any
 
 Frame = dict[str, Any]
 ModificationResult = tuple[str | None, bool | None]
@@ -9,9 +9,9 @@ class Component:
     is_sentinel_frame: bool
     hint: str | None
 
-class StacktraceState:
-    max_frames: int
-    min_frames: int
+class AssembleResult:
+    contributes: bool | None
+    hint: str | None
     invert_stacktrace: bool
 
 class Cache:
@@ -68,16 +68,22 @@ class Enhancements:
         :param exception_data: Exception data to match against rules. Supported
                                fields are "ty", "value", and "mechanism".
         """
-    def update_frame_components_contributions(
-        self, frames: list[Frame], components: list[Component]
-    ) -> StacktraceState:
+    def assemble_stacktrace_component(
+        self,
+        frames: list[Frame],
+        exception_data: dict[str, str | None],
+        components: list[Component],
+    ) -> AssembleResult:
         """
         Modifies a list of `Component`s according to the rules in this Enhancements object.
 
-        The returned list contains the new values of the "category" and
-        "in_app" fields for each frame.
+        It returns an `AssembleResult` containing attributes of a resulting
+        `stacktrace` grouping component,
+        which has to be assembled outside of this function.
 
         :param frames: The list of frames to analyze.
+        :param exception_data: Exception data to match against rules. Supported
+                               fields are "ty", "value", and "mechanism".
         :param components: The list of `Component`s to modify.
                            The `Component` objects are mutated in place.
         """

--- a/python/sentry_ophio/enhancers.pyi
+++ b/python/sentry_ophio/enhancers.pyi
@@ -4,13 +4,13 @@ Frame = dict[str, Any]
 ModificationResult = tuple[str | None, bool | None]
 
 class Component:
-    contributes: bool
+    contributes: bool | None
     is_prefix_frame: bool
     is_sentinel_frame: bool
     hint: str | None
 
 class AssembleResult:
-    contributes: bool | None
+    contributes: bool
     hint: str | None
     invert_stacktrace: bool
 

--- a/rust/src/enhancers/actions.rs
+++ b/rust/src/enhancers/actions.rs
@@ -118,8 +118,8 @@ impl FlagAction {
         for component in components {
             match self.ty {
                 FlagActionType::Group => {
-                    if component.contributes != self.flag {
-                        component.contributes = self.flag;
+                    if component.contributes != Some(self.flag) {
+                        component.contributes = Some(self.flag);
                         let state = if self.flag { "un-ignored" } else { "ignored" };
                         component.hint = Some(format!("{state} by {rule_hint} ({rule})"));
                     }

--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -34,7 +34,7 @@ pub struct Frame {
     /// The [`Rule`] that last modified this frame's `in_app` field.
     ///
     /// This is used for keeping track of grouping contribution information,
-    /// see [`update_frame_components_contributions`](super::Enhancements::update_frame_components_contributions).
+    /// see [`update_frame_components_contributions`](super::Enhancements::assemble_stacktrace_component).
     pub in_app_last_changed: Option<Rule>,
 }
 

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -157,7 +157,7 @@ fn flag_action(input: &str) -> anyhow::Result<(FlagAction, &str)> {
     let (range, after_range) = if let Some(rest) = input.strip_prefix('^') {
         (Some(Range::Up), rest)
     } else if let Some(rest) = input.strip_prefix('v') {
-        (Some(Range::Up), rest)
+        (Some(Range::Down), rest)
     } else {
         (None, input)
     };

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -303,7 +303,7 @@ fn update_components_for_min_frames(
     components: &[Component],
     min_frames: StacktraceVariable<usize>,
 ) -> (bool, Option<String>) {
-    let total_contributes = components
+    let total_contributes: usize = components
         .iter()
         .map(|c| c.contributes.unwrap_or_default() as usize)
         .sum();
@@ -320,7 +320,7 @@ fn update_components_for_min_frames(
         return (contributes, hint);
     }
 
-    if (0..min_frames).contains(&total_contributes) {
+    if total_contributes > 0 && total_contributes < min_frames {
         let mut hint_str = format!("discarded because stack trace only contains {total_contributes} frame{} which is under the configured threshold", if total_contributes == 1 { "" } else {"s"});
 
         if let Some(rule) = setter {

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -8,6 +8,8 @@
 //!
 //! They are applied to stacktraces with [`apply_modifications_to_frames`](Enhancements::apply_modifications_to_frames).
 
+use std::fmt::Write;
+
 use smol_str::SmolStr;
 
 mod actions;
@@ -34,6 +36,13 @@ pub struct ExceptionData {
     pub value: Option<SmolStr>,
     /// The exception's mechanism.
     pub mechanism: Option<SmolStr>,
+}
+
+/// The result of the `assemble_stacktrace_component` fn.
+pub struct AssembleResult {
+    pub contributes: Option<bool>,
+    pub hint: Option<String>,
+    pub invert_stacktrace: bool,
 }
 
 /// A collection of [Rules](Rule) that modify the stacktrace and update grouping information.
@@ -141,12 +150,16 @@ impl Enhancements {
         }
     }
 
-    /// Updates contribution metadata in `components` based on the rules in this collection.
-    pub fn update_frame_components_contributions(
+    /// Assembles a `stacktrace` grouping component out of the given
+    /// `frame` [`Component`]s and [`Frame`]s.
+    ///
+    /// It also updates the [`Component`]s `contributes`, `hint` and other attributes.
+    pub fn assemble_stacktrace_component(
         &self,
         components: &mut [Component],
         frames: &[Frame],
-    ) -> StacktraceState {
+        exception_data: &ExceptionData,
+    ) -> AssembleResult {
         let mut stacktrace_state = StacktraceState::default();
 
         // First, update the `in_app` hints. We have kept track of which rule last set the
@@ -165,6 +178,10 @@ impl Enhancements {
 
         // Apply direct frame actions and update the stack state alongside
         for rule in &self.updater_rules {
+            if !rule.matches_exception(exception_data) {
+                continue;
+            }
+
             for idx in 0..frames.len() {
                 if rule.matches_frame(frames, idx) {
                     rule.update_frame_components_contributions(components, idx);
@@ -174,47 +191,19 @@ impl Enhancements {
         }
 
         // Use the stack state to update frame contributions again to trim
-        // down to max-frames.  min-frames is handled on the other hand for
-        // the entire stacktrace later.
-        let max_frames = stacktrace_state.max_frames.value;
+        // down to `max-frames`.
+        update_components_for_max_frames(components, stacktrace_state.max_frames);
 
-        if max_frames > 0 {
-            let mut ignored = 0;
+        // `min-frames` is handled on the other hand for
+        // the entire stacktrace.
+        let (contributes, hint) =
+            update_components_for_min_frames(components, stacktrace_state.min_frames);
 
-            for component in components.iter_mut().rev() {
-                if !component.contributes {
-                    continue;
-                }
-
-                ignored += 1;
-
-                if ignored <= max_frames {
-                    continue;
-                }
-
-                let hint = format!(
-                    "ignored because only {} {} considered",
-                    max_frames,
-                    if max_frames != 1 {
-                        "frames are"
-                    } else {
-                        "frame is"
-                    },
-                );
-
-                let hint = stacktrace_state
-                    .max_frames
-                    .setter
-                    .as_ref()
-                    .map(|r| format!("{hint} by stack trace rule ({r})"))
-                    .unwrap_or(hint);
-
-                component.contributes = false;
-                component.hint = Some(hint);
-            }
+        AssembleResult {
+            contributes,
+            hint,
+            invert_stacktrace: stacktrace_state.invert_stacktrace.value,
         }
-
-        stacktrace_state
     }
 
     /// Returns an iterator over all rules in this collection.
@@ -246,7 +235,7 @@ impl Extend<Rule> for Enhancements {
 
 #[derive(Debug, Clone, Default)]
 pub struct Component {
-    pub contributes: bool,
+    pub contributes: Option<bool>,
     pub is_prefix_frame: bool,
     pub is_sentinel_frame: bool,
     pub hint: Option<String>,
@@ -263,6 +252,85 @@ pub struct StacktraceState {
     pub max_frames: StacktraceVariable<usize>,
     pub min_frames: StacktraceVariable<usize>,
     pub invert_stacktrace: StacktraceVariable<bool>,
+}
+
+fn update_components_for_max_frames(
+    components: &mut [Component],
+    max_frames: StacktraceVariable<usize>,
+) {
+    let StacktraceVariable {
+        value: max_frames,
+        setter,
+    } = max_frames;
+
+    if max_frames == 0 {
+        return;
+    }
+
+    let mut ignored = 0;
+
+    for component in components.iter_mut().rev() {
+        if !component.contributes.unwrap_or_default() {
+            continue;
+        }
+
+        ignored += 1;
+
+        if ignored <= max_frames {
+            continue;
+        }
+
+        let mut hint = format!(
+            "ignored because only {} {} considered",
+            max_frames,
+            if max_frames != 1 {
+                "frames are"
+            } else {
+                "frame is"
+            },
+        );
+
+        if let Some(rule) = &setter {
+            write!(&mut hint, " by stack trace rule ({rule})").unwrap();
+        }
+
+        component.contributes = Some(false);
+        component.hint = Some(hint);
+    }
+}
+
+fn update_components_for_min_frames(
+    components: &[Component],
+    min_frames: StacktraceVariable<usize>,
+) -> (Option<bool>, Option<String>) {
+    let StacktraceVariable {
+        value: min_frames,
+        setter,
+    } = min_frames;
+
+    let mut contributes = None;
+    let mut hint = None;
+
+    if min_frames == 0 {
+        return (contributes, hint);
+    }
+
+    let total_contributes = components
+        .iter()
+        .map(|c| c.contributes.unwrap_or_default() as usize)
+        .sum();
+    if (0..min_frames).contains(&total_contributes) {
+        let mut hint_str = format!("discarded because stack trace only contains {total_contributes} frame{} which is under the configured threshold", if total_contributes == 1 { "" } else {"s"});
+
+        if let Some(rule) = setter {
+            write!(&mut hint_str, " by stack trace rule ({rule})").unwrap();
+        }
+
+        contributes = Some(false);
+        hint = Some(hint_str);
+    }
+
+    (contributes, hint)
 }
 
 #[cfg(test)]

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -303,22 +303,22 @@ fn update_components_for_min_frames(
     components: &[Component],
     min_frames: StacktraceVariable<usize>,
 ) -> (bool, Option<String>) {
+    let total_contributes = components
+        .iter()
+        .map(|c| c.contributes.unwrap_or_default() as usize)
+        .sum();
+
+    let mut hint = None;
+    let mut contributes = total_contributes > 0;
+
     let StacktraceVariable {
         value: min_frames,
         setter,
     } = min_frames;
 
-    let mut hint = None;
-
     if min_frames == 0 {
-        return (false, hint);
+        return (contributes, hint);
     }
-
-    let total_contributes = components
-        .iter()
-        .map(|c| c.contributes.unwrap_or_default() as usize)
-        .sum();
-    let mut contributes = total_contributes > 0;
 
     if (0..min_frames).contains(&total_contributes) {
         let mut hint_str = format!("discarded because stack trace only contains {total_contributes} frame{} which is under the configured threshold", if total_contributes == 1 { "" } else {"s"});

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -85,11 +85,12 @@ def test_sentinel_and_prefix(action, type):
     enhancer = Enhancements.parse(f"function:foo {action}{type}", cache)
 
     frames = [create_match_frame({"function": "foo"}, "whatever")]
-    components = [Component(contributes=True, is_prefix_frame=False, is_sentinel_frame=False)]
+    frame_components = [Component(contributes=None, is_prefix_frame=False, is_sentinel_frame=False)]
 
-    assert not getattr(components[0], f"is_{type}_frame")
+    assert not getattr(frame_components[0], f"is_{type}_frame")
 
-    enhancer.update_frame_components_contributions(frames, components)
+    exception_data = {"ty": None, "value": None, "mechanism": None}
+    enhancer.assemble_stacktrace_component(frames, exception_data,frame_components)
 
     expected = action == "+"
-    assert getattr(components[0], f"is_{type}_frame") is expected
+    assert getattr(frame_components[0], f"is_{type}_frame") is expected


### PR DESCRIPTION
This ports the handling of `min-frames` to the Rust code, adds `exception_data` matching, and changes some internal types around.

The PR also contains a typo-fix that came from #40. We tested this PR together with https://github.com/getsentry/sentry/pull/66587 which runs the Sentry unit tests without any observable differences.