### PR TITLE
Fully replicate `in_app` hint logic

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -16,6 +16,7 @@ pub struct Frame {
     package: OptStr,
     path: OptStr,
     in_app: Option<bool>,
+    orig_in_app: Option<i8>,
 }
 
 struct OptStr(Option<enhancers::StringField>);
@@ -193,7 +194,11 @@ fn convert_frame_from_py(frame: Bound<'_, PyAny>) -> PyResult<enhancers::Frame> 
         path: frame.path.0,
 
         in_app: frame.in_app,
-        in_app_last_changed: None,
+        orig_in_app: frame.orig_in_app.map(|in_app| match in_app {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }),
     };
     Ok(frame)
 }

--- a/rust/src/enhancers/actions.rs
+++ b/rust/src/enhancers/actions.rs
@@ -110,7 +110,7 @@ impl FlagAction {
     }
 
     /// Applies this action's modification to `frames` at the index `idx`.
-    pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize, _rule: &Rule) {
+    pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize) {
         if self.ty == FlagActionType::App {
             for frame in self.slice_to_range_mut(frames, idx) {
                 frame.in_app = Some(self.flag);
@@ -265,9 +265,9 @@ impl Action {
     }
 
     /// Applies this action's modification to `frames` at the index `idx`.
-    pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize, rule: &Rule) {
+    pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize) {
         match self {
-            Action::Flag(action) => action.apply_modifications_to_frame(frames, idx, rule),
+            Action::Flag(action) => action.apply_modifications_to_frame(frames, idx),
             Action::Var(action) => action.apply_modifications_to_frame(frames, idx),
         }
     }

--- a/rust/src/enhancers/matchers.rs
+++ b/rust/src/enhancers/matchers.rs
@@ -606,4 +606,25 @@ mod tests {
             "native"
         )));
     }
+
+    #[test]
+    fn test_negated_display() {
+        let input = r#"!function:log_demo::* -group"#;
+        let enhancements = Enhancements::parse(input, &mut Default::default()).unwrap();
+        let rule = enhancements.all_rules.into_iter().next().unwrap();
+
+        assert_eq!(rule.to_string(), "!function:log_demo::* -group");
+    }
+
+    #[test]
+    fn test_case_sensitive_display() {
+        let input = r#"family:native package:**/Containers/Bundle/Application/**            +app"#;
+        let enhancements = Enhancements::parse(input, &mut Default::default()).unwrap();
+        let rule = enhancements.all_rules.into_iter().next().unwrap();
+
+        assert_eq!(
+            rule.to_string(),
+            "family:native package:**/Containers/Bundle/Application/** +app"
+        );
+    }
 }

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -162,20 +162,6 @@ impl Enhancements {
     ) -> AssembleResult {
         let mut stacktrace_state = StacktraceState::default();
 
-        // First, update the `in_app` hints. We have kept track of which rule last set the
-        // `in_app` field of each frame, so we don't need to iterate over the rules again for this.
-        for (component, frame) in components.iter_mut().zip(frames.iter()) {
-            if let Some(rule) = frame.in_app_last_changed.as_ref() {
-                // in_app is definitely set, otherwise `in_app_last_changed` would be `None`
-                let state = if frame.in_app.unwrap() {
-                    "in-app"
-                } else {
-                    "out of app"
-                };
-                component.hint = Some(format!("marked {state} by stack trace rule ({rule})"));
-            }
-        }
-
         // Apply direct frame actions and update the stack state alongside
         for rule in &self.updater_rules {
             if !rule.matches_exception(exception_data) {
@@ -184,7 +170,7 @@ impl Enhancements {
 
             for idx in 0..frames.len() {
                 if rule.matches_frame(frames, idx) {
-                    rule.update_frame_components_contributions(components, idx);
+                    rule.update_frame_components_contributions(components, frames, idx);
                     rule.modify_stacktrace_state(&mut stacktrace_state);
                 }
             }

--- a/rust/src/enhancers/rules.rs
+++ b/rust/src/enhancers/rules.rs
@@ -121,9 +121,14 @@ impl Rule {
     }
 
     /// Updates grouping component contribution information.
-    pub fn update_frame_components_contributions(&self, components: &mut [Component], idx: usize) {
+    pub fn update_frame_components_contributions(
+        &self,
+        components: &mut [Component],
+        frames: &[Frame],
+        idx: usize,
+    ) {
         for action in &self.0.actions {
-            action.update_frame_components_contributions(components, idx, self);
+            action.update_frame_components_contributions(components, frames, idx, self);
         }
     }
 }

--- a/rust/src/enhancers/rules.rs
+++ b/rust/src/enhancers/rules.rs
@@ -116,7 +116,7 @@ impl Rule {
     /// Applies all modifications from this rule's actions to `frames` at the index `idx`.
     pub fn apply_modifications_to_frame(&self, frames: &mut [Frame], idx: usize) {
         for action in &self.0.actions {
-            action.apply_modifications_to_frame(frames, idx, self)
+            action.apply_modifications_to_frame(frames, idx)
         }
     }
 

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -45,6 +45,7 @@ def create_match_frame(frame_data: dict, platform: Optional[str]) -> dict:
         family=frame_data.get("platform") or platform,
         function=frame_data.get("function"),
         in_app=frame_data.get("in_app") or False,
+        orig_in_app=get_path(frame_data, "data", "orig_in_app"),
         module=get_path(frame_data, "module"),
         package=frame_data.get("package"),
         path=frame_data.get("abs_path") or frame_data.get("filename"),


### PR DESCRIPTION
Instead of using `in_app_last_changed`, this rather takes the `orig_in_app` value directly from Python, and replicates the `hint` attaching logic exactly as it exists in Python.