### PR TITLE
Implement a crc32/Ketama-based consistent hashing scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brownstone"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +165,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +182,16 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -250,6 +279,16 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -399,6 +438,16 @@ name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -751,9 +800,11 @@ name = "rust-ophio"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "crc32fast",
  "divan",
  "globset",
  "lru",
+ "md-5",
  "regex",
  "rmp-serde",
  "serde",
@@ -1006,6 +1057,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ dependencies = [
  "crc32fast",
  "divan",
  "globset",
+ "indexmap",
  "lru",
  "md-5",
  "regex",

--- a/bindings/src/ketama.rs
+++ b/bindings/src/ketama.rs
@@ -18,7 +18,15 @@ impl KetamaPool {
         Ok(Self(ketama::KetamaPool::new(&str_keys)))
     }
 
-    fn get_slot(&self, key: &str) -> usize {
-        self.0.get_slot(key)
+    fn add_node(&mut self, server: &str) {
+        self.0.add_node(server)
+    }
+
+    fn remove_node(&mut self, server: &str) {
+        self.0.remove_node(server)
+    }
+
+    fn get_node(&self, key: &str) -> &str {
+        self.0.get_node(key)
     }
 }

--- a/bindings/src/ketama.rs
+++ b/bindings/src/ketama.rs
@@ -1,0 +1,24 @@
+use pyo3::prelude::*;
+use pyo3::types::PyList;
+use rust_ophio::ketama;
+
+#[pyclass]
+pub struct KetamaPool(ketama::KetamaPool);
+
+#[pymethods]
+impl KetamaPool {
+    #[new]
+    fn new(keys: Bound<'_, PyList>) -> PyResult<Self> {
+        let keys = keys
+            .into_iter()
+            .map(|k| k.extract())
+            .collect::<PyResult<Vec<String>>>()?;
+        let str_keys: Vec<&str> = keys.iter().map(|k| k.as_str()).collect();
+
+        Ok(Self(ketama::KetamaPool::new(&str_keys)))
+    }
+
+    fn get_slot(&self, key: &str) -> usize {
+        self.0.get_slot(key)
+    }
+}

--- a/bindings/src/lib.rs
+++ b/bindings/src/lib.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 
 mod enhancers;
+mod ketama;
 mod proguard;
 
 #[pymodule]
@@ -9,6 +10,7 @@ fn _bindings(_py: Python, m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<enhancers::Component>()?;
     m.add_class::<enhancers::Enhancements>()?;
     m.add_class::<enhancers::AssembleResult>()?;
+    m.add_class::<ketama::KetamaPool>()?;
     m.add_class::<proguard::JavaStackFrame>()?;
     m.add_class::<proguard::ProguardMapper>()?;
 

--- a/python/sentry_ophio/ketama.py
+++ b/python/sentry_ophio/ketama.py
@@ -1,0 +1,3 @@
+from ._bindings import KetamaPool
+
+KetamaPool.__module__ = __name__

--- a/python/sentry_ophio/ketama.pyi
+++ b/python/sentry_ophio/ketama.pyi
@@ -2,15 +2,24 @@ class KetamaPool:
     """
     A Consistent hashing pool based on the "Ketama" algorithm.
     """
-    def __new__(cls, slots: list[str]) -> KetamaPool:
+    def __new__(cls, nodes: list[str]) -> KetamaPool:
         """
-        Creates a new consistent hashing pool, using the given `slots` as keys.
+        Creates a new consistent hashing pool, using the given `nodes` as keys.
         """
 
-    def get_slot(
-        self, key: str
-    ) -> int:
+    def add_node(self, node: str):
         """
-        Returns the index within the initially provided `slots` to which the
-        given `key` is being associated.
+        Adds a new `node` to the pool.
+        """
+
+    def remove_node(self, node: str):
+        """
+        Remove the given `node` from the pool.
+        """
+
+    def get_node(
+        self, key: str
+    ) -> str:
+        """
+        Returns the node name which will host the given `key`.
         """

--- a/python/sentry_ophio/ketama.pyi
+++ b/python/sentry_ophio/ketama.pyi
@@ -1,0 +1,16 @@
+class KetamaPool:
+    """
+    A Consistent hashing pool based on the "Ketama" algorithm.
+    """
+    def __new__(cls, slots: list[str]) -> KetamaPool:
+        """
+        Creates a new consistent hashing pool, using the given `slots` as keys.
+        """
+
+    def get_slot(
+        self, key: str
+    ) -> int:
+        """
+        Returns the index within the initially provided `slots` to which the
+        given `key` is being associated.
+        """

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,8 +9,10 @@ testing = ["dep:serde_json"]
 
 [dependencies]
 anyhow = "1.0.79"
+crc32fast = "1.4.0"
 globset = "0.4.14"
 lru = "0.12.1"
+md-5 = "0.10.6"
 regex = "1.10.2"
 rmp-serde = "1.1.2"
 serde = { version = "1.0.195", features = ["derive"] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ testing = ["dep:serde_json"]
 anyhow = "1.0.79"
 crc32fast = "1.4.0"
 globset = "0.4.14"
+indexmap = "2.2.6"
 lru = "0.12.1"
 md-5 = "0.10.6"
 regex = "1.10.2"

--- a/rust/src/ketama.rs
+++ b/rust/src/ketama.rs
@@ -57,7 +57,7 @@ fn create_server_ranking(keys: &[&str]) -> Vec<ServerRank> {
             let md5_hash = Md5::digest(&hash_buf);
 
             for alignment in 0..POINTS_PER_HASH {
-                let value = u32::from_le_bytes([
+                let value = u32::from_be_bytes([
                     md5_hash[3 + alignment * 4],
                     md5_hash[2 + alignment * 4],
                     md5_hash[1 + alignment * 4],

--- a/rust/src/ketama.rs
+++ b/rust/src/ketama.rs
@@ -1,27 +1,66 @@
+use indexmap::IndexSet;
 use md5::{Digest, Md5};
+use smol_str::SmolStr;
 
+/// A node pool that does consistent hashing based on the "Ketama" algorithm.
 pub struct KetamaPool {
-    /// The list of Servers, sorted by their ranking value.
-    ranking: Vec<ServerRank>,
+    /// The set of nodes that this pool knows about.
+    nodes: IndexSet<SmolStr>,
+    /// The list of Servers, sorted by their hash value.
+    hash_ring: Vec<NodeHash>,
+
+    /// A reusable scratch buffer to format node hash keys into.
+    hash_buf: String,
 }
 
-struct ServerRank {
+/// A Node in the main [`KetamaPool::hash_ring`] list.
+struct NodeHash {
+    /// The hash value, used for sorting and binary search.
     value: u32,
+    /// The index of the node in the main [`KetamaPool::nodes`] set.
     index: u32,
 }
 
+const POINTS_PER_HASH: usize = 4;
+const POINTS_PER_SERVER: usize = 40;
+
 impl KetamaPool {
-    /// Builds a new pool using the given hash keys.
-    pub fn new(keys: &[&str]) -> Self {
-        let ranking = create_server_ranking(keys);
-        Self { ranking }
+    /// Builds a new pool with the given `initial_nodes`.
+    pub fn new(initial_nodes: &[&str]) -> Self {
+        let mut slf = Self {
+            nodes: initial_nodes.iter().map(SmolStr::new).collect(),
+            hash_ring: vec![],
+            hash_buf: String::new(),
+        };
+        slf.update_node_ranking();
+        slf
     }
 
-    /// Picks a slot for the given `key`.
+    /// Adds a new `node` to the pool.
+    pub fn add_node(&mut self, node: &str) {
+        if self.nodes.insert(node.into()) {
+            // in theory its possible to do `add`s incrementally, but its infrequent so probably not worth the effort.
+            self.update_node_ranking();
+        }
+    }
+
+    /// Remove the given `node` from the pool.
+    pub fn remove_node(&mut self, node: &str) {
+        self.nodes.swap_remove(node);
+        self.update_node_ranking();
+    }
+
+    /// Returns the node name which will host the given `key`.
     ///
-    /// The "slot" here is an index into the origin list of keys this pool was constructed with.
-    pub fn get_slot(&self, key: &str) -> usize {
-        if self.ranking.len() == 1 {
+    /// Panics if no node has been added to this pool.
+    pub fn get_node(&self, key: &str) -> &str {
+        let idx = self.get_node_idx(key);
+        self.nodes.get_index(idx).unwrap()
+    }
+
+    /// Picks a node in this pool to host the given `key`.
+    pub fn get_node_idx(&self, key: &str) -> usize {
+        if self.hash_ring.len() <= 1 {
             return 0;
         }
 
@@ -32,46 +71,90 @@ impl KetamaPool {
         };
 
         let ranking_idx = match self
-            .ranking
+            .hash_ring
             .binary_search_by_key(&key_hash, |rank| rank.value)
         {
             Ok(idx) => idx,
             Err(idx) => idx,
         };
-        self.ranking[ranking_idx % self.ranking.len()].index as usize
+        self.hash_ring[ranking_idx % self.hash_ring.len()].index as usize
+    }
+
+    fn update_node_ranking(&mut self) {
+        self.hash_ring.clear();
+        self.hash_ring
+            .reserve(POINTS_PER_SERVER * POINTS_PER_HASH * self.nodes.len());
+
+        for (idx, key) in self.nodes.iter().enumerate() {
+            for point_idx in 0..POINTS_PER_SERVER {
+                use std::fmt::Write;
+                self.hash_buf.clear();
+                write!(&mut self.hash_buf, "{key}-{point_idx}").unwrap();
+                let md5_hash = Md5::digest(&self.hash_buf);
+
+                for alignment in 0..POINTS_PER_HASH {
+                    let value = u32::from_be_bytes([
+                        md5_hash[3 + alignment * 4],
+                        md5_hash[2 + alignment * 4],
+                        md5_hash[1 + alignment * 4],
+                        md5_hash[alignment * 4],
+                    ]);
+                    self.hash_ring.push(NodeHash {
+                        value,
+                        index: idx as u32,
+                    });
+                }
+            }
+        }
+
+        self.hash_ring.sort_by_key(|rank| rank.value);
     }
 }
 
-const POINTS_PER_HASH: usize = 4;
-const POINTS_PER_SERVER: usize = 40;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-fn create_server_ranking(keys: &[&str]) -> Vec<ServerRank> {
-    let mut ranking = Vec::with_capacity(POINTS_PER_SERVER * POINTS_PER_HASH * keys.len());
-    let mut hash_buf = String::new();
+    #[test]
+    fn test_consistent_hashing() {
+        let mut pool = KetamaPool::new(&["node-a", "node-b", "node-c", "node-d", "node-e"]);
 
-    for (idx, key) in keys.iter().enumerate() {
-        for point_idx in 0..POINTS_PER_SERVER {
-            use std::fmt::Write;
-            hash_buf.clear();
-            write!(&mut hash_buf, "{key}-{point_idx}").unwrap();
-            let md5_hash = Md5::digest(&hash_buf);
+        assert_eq!(pool.get_node("key-a"), "node-e");
+        assert_eq!(pool.get_node("key-b"), "node-d");
+        assert_eq!(pool.get_node("key-c"), "node-b");
+        assert_eq!(pool.get_node("key-d"), "node-a");
+        assert_eq!(pool.get_node("key-e"), "node-e");
+        assert_eq!(pool.get_node("key-aa"), "node-b");
 
-            for alignment in 0..POINTS_PER_HASH {
-                let value = u32::from_be_bytes([
-                    md5_hash[3 + alignment * 4],
-                    md5_hash[2 + alignment * 4],
-                    md5_hash[1 + alignment * 4],
-                    md5_hash[alignment * 4],
-                ]);
-                ranking.push(ServerRank {
-                    value,
-                    index: idx as u32,
-                });
-            }
-        }
+        pool.add_node("node-f");
+
+        // most existing keys are unchanged
+        assert_eq!(pool.get_node("key-a"), "node-e");
+        assert_eq!(pool.get_node("key-b"), "node-d");
+        assert_eq!(pool.get_node("key-c"), "node-b");
+        assert_eq!(pool.get_node("key-d"), "node-a");
+        assert_eq!(pool.get_node("key-e"), "node-e");
+        // one key has moved to the new node
+        assert_eq!(pool.get_node("key-aa"), "node-f"); // <-
+
+        pool.remove_node("node-f");
+
+        // we are back to the original assignment
+        assert_eq!(pool.get_node("key-a"), "node-e");
+        assert_eq!(pool.get_node("key-b"), "node-d");
+        assert_eq!(pool.get_node("key-c"), "node-b");
+        assert_eq!(pool.get_node("key-d"), "node-a");
+        assert_eq!(pool.get_node("key-e"), "node-e");
+        assert_eq!(pool.get_node("key-aa"), "node-b"); // <-
+
+        pool.remove_node("node-e");
+
+        // all keys of "node-e" were re-assigned, others are untouched
+        assert_eq!(pool.get_node("key-a"), "node-c"); // <-
+        assert_eq!(pool.get_node("key-b"), "node-d");
+        assert_eq!(pool.get_node("key-c"), "node-b");
+        assert_eq!(pool.get_node("key-d"), "node-a");
+        assert_eq!(pool.get_node("key-e"), "node-b"); // <-
+        assert_eq!(pool.get_node("key-aa"), "node-b");
     }
-
-    ranking.sort_by_key(|rank| rank.value);
-
-    ranking
 }

--- a/rust/src/ketama.rs
+++ b/rust/src/ketama.rs
@@ -38,7 +38,7 @@ impl KetamaPool {
             Ok(idx) => idx,
             Err(idx) => idx,
         };
-        self.ranking[ranking_idx].index as usize
+        self.ranking[ranking_idx % self.ranking.len()].index as usize
     }
 }
 

--- a/rust/src/ketama.rs
+++ b/rust/src/ketama.rs
@@ -1,0 +1,77 @@
+use md5::{Digest, Md5};
+
+pub struct KetamaPool {
+    /// The list of Servers, sorted by their ranking value.
+    ranking: Vec<ServerRank>,
+}
+
+struct ServerRank {
+    value: u32,
+    index: u32,
+}
+
+impl KetamaPool {
+    /// Builds a new pool using the given hash keys.
+    pub fn new(keys: &[&str]) -> Self {
+        let ranking = create_server_ranking(keys);
+        Self { ranking }
+    }
+
+    /// Picks a slot for the given `key`.
+    ///
+    /// The "slot" here is an index into the origin list of keys this pool was constructed with.
+    pub fn get_slot(&self, key: &str) -> usize {
+        if self.ranking.len() == 1 {
+            return 0;
+        }
+
+        let key_hash = if key.is_empty() {
+            0
+        } else {
+            crc32fast::hash(key.as_ref())
+        };
+
+        let ranking_idx = match self
+            .ranking
+            .binary_search_by_key(&key_hash, |rank| rank.value)
+        {
+            Ok(idx) => idx,
+            Err(idx) => idx,
+        };
+        self.ranking[ranking_idx].index as usize
+    }
+}
+
+const POINTS_PER_HASH: usize = 4;
+const POINTS_PER_SERVER: usize = 40;
+
+fn create_server_ranking(keys: &[&str]) -> Vec<ServerRank> {
+    let mut ranking = Vec::with_capacity(POINTS_PER_SERVER * POINTS_PER_HASH * keys.len());
+    let mut hash_buf = String::new();
+
+    for (idx, key) in keys.iter().enumerate() {
+        for point_idx in 0..POINTS_PER_SERVER {
+            use std::fmt::Write;
+            hash_buf.clear();
+            write!(&mut hash_buf, "{key}-{point_idx}").unwrap();
+            let md5_hash = Md5::digest(&hash_buf);
+
+            for alignment in 0..POINTS_PER_HASH {
+                let value = u32::from_le_bytes([
+                    md5_hash[3 + alignment * 4],
+                    md5_hash[2 + alignment * 4],
+                    md5_hash[1 + alignment * 4],
+                    md5_hash[alignment * 4],
+                ]);
+                ranking.push(ServerRank {
+                    value,
+                    index: idx as u32,
+                });
+            }
+        }
+    }
+
+    ranking.sort_by_key(|rank| rank.value);
+
+    ranking
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod enhancers;
+pub mod ketama;

--- a/tests/test_ketama.py
+++ b/tests/test_ketama.py
@@ -7,10 +7,9 @@ def test_hasher():
     assert pool.get_slot("b") == 0
 
     pool = KetamaPool(["a", "b", "c", "d", "e"])
-    assert pool.get_slot("") == 0
 
     # these here are pretty random depending on the hashing state
     assert pool.get_slot("a") == 4
-    assert pool.get_slot("b") == 0
-    assert pool.get_slot("c") == 2
+    assert pool.get_slot("b") == 3
+    assert pool.get_slot("c") == 3
 

--- a/tests/test_ketama.py
+++ b/tests/test_ketama.py
@@ -1,0 +1,16 @@
+from sentry_ophio.ketama import KetamaPool
+
+
+def test_hasher():
+    pool = KetamaPool(["a"])
+    assert pool.get_slot("a") == 0
+    assert pool.get_slot("b") == 0
+
+    pool = KetamaPool(["a", "b", "c", "d", "e"])
+    assert pool.get_slot("") == 0
+
+    # these here are pretty random depending on the hashing state
+    assert pool.get_slot("a") == 4
+    assert pool.get_slot("b") == 0
+    assert pool.get_slot("c") == 2
+

--- a/tests/test_ketama.py
+++ b/tests/test_ketama.py
@@ -3,13 +3,54 @@ from sentry_ophio.ketama import KetamaPool
 
 def test_hasher():
     pool = KetamaPool(["a"])
-    assert pool.get_slot("a") == 0
-    assert pool.get_slot("b") == 0
+    assert pool.get_node("a") == "a"
+    assert pool.get_node("b") == "a"
 
     pool = KetamaPool(["a", "b", "c", "d", "e"])
 
     # these here are pretty random depending on the hashing state
-    assert pool.get_slot("a") == 4
-    assert pool.get_slot("b") == 3
-    assert pool.get_slot("c") == 3
+    assert pool.get_node("a") == "e"
+    assert pool.get_node("b") == "d"
+    assert pool.get_node("c") == "d"
 
+
+def test_consistent_hashing():
+    pool = KetamaPool(["node-a", "node-b", "node-c", "node-d", "node-e"])
+
+    assert pool.get_node("key-a") == "node-e"
+    assert pool.get_node("key-b") == "node-d"
+    assert pool.get_node("key-c") == "node-b"
+    assert pool.get_node("key-d") == "node-a"
+    assert pool.get_node("key-e") == "node-e"
+    assert pool.get_node("key-aa") == "node-b"
+
+    pool.add_node("node-f")
+
+    # most existing keys are unchanged
+    assert pool.get_node("key-a") == "node-e"
+    assert pool.get_node("key-b") == "node-d"
+    assert pool.get_node("key-c") == "node-b"
+    assert pool.get_node("key-d") == "node-a"
+    assert pool.get_node("key-e") == "node-e"
+    # one key has moved to the new node
+    assert pool.get_node("key-aa") == "node-f" # <-
+
+    pool.remove_node("node-f")
+
+    # we are back to the original assignment
+    assert pool.get_node("key-a") == "node-e"
+    assert pool.get_node("key-b") == "node-d"
+    assert pool.get_node("key-c") == "node-b"
+    assert pool.get_node("key-d") == "node-a"
+    assert pool.get_node("key-e") == "node-e"
+    assert pool.get_node("key-aa") == "node-b" # <-
+
+    pool.remove_node("node-e")
+
+    # all keys of "node-e" were re-assigned, others are untouched
+    assert pool.get_node("key-a") == "node-c" # <-
+    assert pool.get_node("key-b") == "node-d"
+    assert pool.get_node("key-c") == "node-b"
+    assert pool.get_node("key-d") == "node-a"
+    assert pool.get_node("key-e") == "node-b" # <-
+    assert pool.get_node("key-aa") == "node-b"


### PR DESCRIPTION
This pretty much does https://github.com/getsentry/sentry/issues/68599 by porting the `twemcache` ketama code to Rust, while simplifying it quite a bit.

Our production config does not use different server weights, so all the weight-dependant code was removed.