### PR TITLE
feat: Add methods we'll need to build a django integration

### DIFF
--- a/bindings/src/ketama.rs
+++ b/bindings/src/ketama.rs
@@ -21,4 +21,12 @@ impl KetamaPool {
     fn get_slot(&self, key: &str) -> usize {
         self.0.get_slot(key)
     }
+
+    fn add_node(&mut self, server: &str) {
+        self.0.add_node(server)
+    }
+
+    fn remove_node(&mut self, server: &str) {
+        self.0.remove_node(server)
+    }
 }

--- a/python/sentry_ophio/ketama.pyi
+++ b/python/sentry_ophio/ketama.pyi
@@ -25,7 +25,7 @@ class KetamaPool:
         Remove a node
         """
 
-    def get_node(self, key: str) -> str | None:
+    def get_node(self, key: str) -> str:
         """
         Get a node
         """

--- a/python/sentry_ophio/ketama.pyi
+++ b/python/sentry_ophio/ketama.pyi
@@ -14,3 +14,18 @@ class KetamaPool:
         Returns the index within the initially provided `slots` to which the
         given `key` is being associated.
         """
+
+    def add_node(self, key: str):
+        """
+        Add a new node
+        """
+
+    def remove_node(self, key: str):
+        """
+        Remove a node
+        """
+
+    def get_node(self, key: str) -> str | None:
+        """
+        Get a node
+        """

--- a/rust/src/ketama.rs
+++ b/rust/src/ketama.rs
@@ -45,12 +45,13 @@ impl KetamaPool {
 
     /// Adds the appropriate rankings for the new node
     pub fn add_node(&mut self, server_name: &str) {
-      create_server_ranking(&[server_name], &mut self.ranking);
+        create_server_ranking(&[server_name], &mut self.ranking);
     }
 
     /// Removes the rankings corresponding to the server name
     pub fn remove_node(&mut self, server_name: &str) {
-        self.ranking.retain(|ranking| ranking.server_name == server_name)
+        self.ranking
+            .retain(|ranking| ranking.server_name == server_name)
     }
 
     pub fn get_node(&self, key: &str) -> &str {

--- a/rust/src/ketama.rs
+++ b/rust/src/ketama.rs
@@ -2,18 +2,20 @@ use md5::{Digest, Md5};
 
 pub struct KetamaPool {
     /// The list of Servers, sorted by their ranking value.
-    ranking: Vec<ServerRank>,
+    pub ranking: Vec<ServerRank>,
 }
 
-struct ServerRank {
-    value: u32,
-    index: u32,
+pub struct ServerRank {
+    pub server_name: String,
+    pub value: u32,
+    pub index: u32,
 }
 
 impl KetamaPool {
     /// Builds a new pool using the given hash keys.
     pub fn new(keys: &[&str]) -> Self {
-        let ranking = create_server_ranking(keys);
+        let mut ranking = Vec::with_capacity(POINTS_PER_SERVER * POINTS_PER_HASH * keys.len());
+        create_server_ranking(keys, &mut ranking);
         Self { ranking }
     }
 
@@ -40,13 +42,27 @@ impl KetamaPool {
         };
         self.ranking[ranking_idx % self.ranking.len()].index as usize
     }
+
+    /// Adds the appropriate rankings for the new node
+    pub fn add_node(&mut self, server_name: &str) {
+      create_server_ranking(&[server_name], &mut self.ranking);
+    }
+
+    /// Removes the rankings corresponding to the server name
+    pub fn remove_node(&mut self, server_name: &str) {
+        self.ranking.retain(|ranking| ranking.server_name == server_name)
+    }
+
+    pub fn get_node(&self, key: &str) -> &str {
+        let slot = self.get_slot(key);
+        self.ranking[slot].server_name.as_ref()
+    }
 }
 
 const POINTS_PER_HASH: usize = 4;
 const POINTS_PER_SERVER: usize = 40;
 
-fn create_server_ranking(keys: &[&str]) -> Vec<ServerRank> {
-    let mut ranking = Vec::with_capacity(POINTS_PER_SERVER * POINTS_PER_HASH * keys.len());
+fn create_server_ranking(keys: &[&str], ranking: &mut Vec<ServerRank>) {
     let mut hash_buf = String::new();
 
     for (idx, key) in keys.iter().enumerate() {
@@ -57,13 +73,9 @@ fn create_server_ranking(keys: &[&str]) -> Vec<ServerRank> {
             let md5_hash = Md5::digest(&hash_buf);
 
             for alignment in 0..POINTS_PER_HASH {
-                let value = u32::from_be_bytes([
-                    md5_hash[3 + alignment * 4],
-                    md5_hash[2 + alignment * 4],
-                    md5_hash[1 + alignment * 4],
-                    md5_hash[alignment * 4],
-                ]);
+                let value = ketama_hash(md5_hash.as_slice(), alignment);
                 ranking.push(ServerRank {
+                    server_name: key.to_string(),
                     value,
                     index: idx as u32,
                 });
@@ -72,6 +84,55 @@ fn create_server_ranking(keys: &[&str]) -> Vec<ServerRank> {
     }
 
     ranking.sort_by_key(|rank| rank.value);
+}
 
-    ranking
+fn ketama_hash(md5_hash: &[u8], alignment: usize) -> u32 {
+    u32::from_be_bytes([
+        md5_hash[3 + alignment * 4],
+        md5_hash[2 + alignment * 4],
+        md5_hash[1 + alignment * 4],
+        md5_hash[alignment * 4],
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ketama::*;
+    use md5::{Digest, Md5};
+
+    #[test]
+    fn it_produces_correct_ketama_hashes() {
+        let pool = KetamaPool::new(&["server1"]);
+        assert_eq!(pool.ranking.len(), 1 * POINTS_PER_SERVER * POINTS_PER_HASH);
+
+        let hash = Md5::digest("server1-8");
+        /*
+        Results taken from twemproxy tests:
+
+        expect_same_uint32_t(3853726576U, ketama_hash("server1-8", strlen("server1-8"), 0), "should have expected ketama_hash for server1-8 index 0");
+        expect_same_uint32_t(2667054752U, ketama_hash("server1-8", strlen("server1-8"), 3), "should have expected ketama_hash for server1-8 index 3");
+        */
+        assert_eq!(3853726576, ketama_hash(hash.as_slice(), 0));
+        assert_eq!(2667054752, ketama_hash(hash.as_slice(), 3));
+    }
+
+    #[test]
+    fn it_can_add_and_remove_servers() {
+        let mut pool = KetamaPool::new(&["server1"]);
+        pool.add_node("server2");
+        assert_eq!(2 * POINTS_PER_SERVER * POINTS_PER_HASH, pool.ranking.len());
+
+        pool.remove_node("server2");
+        assert_eq!(1 * POINTS_PER_SERVER * POINTS_PER_HASH, pool.ranking.len());
+    }
+
+    #[test]
+    fn it_can_get_nodes() {
+        let pool = KetamaPool::new(&["server1", "server2"]);
+        let result = pool.get_node("organization:2");
+        assert_eq!("server2", result);
+
+        let result = pool.get_node("organization:1");
+        assert_eq!("server1", result);
+    }
 }

--- a/tests/test_ketama.py
+++ b/tests/test_ketama.py
@@ -1,7 +1,7 @@
 from sentry_ophio.ketama import KetamaPool
 
 
-def test_hasher():
+def test_get_slot():
     pool = KetamaPool(["a"])
     assert pool.get_slot("a") == 0
     assert pool.get_slot("b") == 0
@@ -13,3 +13,7 @@ def test_hasher():
     assert pool.get_slot("b") == 3
     assert pool.get_slot("c") == 3
 
+def test_add_remove_server():
+    pool = KetamaPool(["a"])
+    pool.add_node("server1");
+    pool.remove_node("server1");


### PR DESCRIPTION
The Pymemcache package allows us to inject a `hasher` which needs to implement the protocol of get_node, add_node, remove_node. Adding those methods to Ketama allows us to build a very simple wrapper around the Rust binding that will work nicely with Django

Paired with @anonrig on this.