### PR TITLE
WIP: Serialize Enhancers

### DIFF
--- a/rust/src/enhancers/families.rs
+++ b/rust/src/enhancers/families.rs
@@ -9,7 +9,7 @@
 /// * `0b010` represents `"native"`
 /// * `0b100` represents `"javascript"`
 /// * `u8::MAX` represents `"all"`
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Families(u8);
 
 const BITFIELD_OTHER: u8 = 0b001;

--- a/rust/src/enhancers/frame.rs
+++ b/rust/src/enhancers/frame.rs
@@ -37,7 +37,7 @@ pub struct Frame {
 }
 
 /// The name of a string-valued field in a frame.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FrameField {
     Category,
     Function,

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -22,7 +22,7 @@ mod matchers;
 mod rules;
 
 pub use cache::*;
-use config_structure::{EncodedAction, EncodedEnhancements, EncodedMatcher};
+use config_structure::EncodedEnhancements;
 pub use families::Families;
 pub use frame::{Frame, StringField};
 pub use rules::Rule;
@@ -109,18 +109,7 @@ impl Enhancements {
 
         let all_rules: Vec<_> = rules
             .into_iter()
-            .map(|r| {
-                let matchers =
-                    r.0.into_iter()
-                        .map(|encoded| EncodedMatcher::into_matcher(encoded, &mut cache.regex))
-                        .collect::<anyhow::Result<_>>()?;
-                let actions =
-                    r.1.into_iter()
-                        .map(EncodedAction::into_action)
-                        .collect::<anyhow::Result<_>>()?;
-
-                Ok(Rule::new(matchers, actions))
-            })
+            .map(|r| r.into_rule(&mut cache.regex))
             .collect::<anyhow::Result<_>>()?;
 
         Ok(Enhancements::new(all_rules))

--- a/rust/src/enhancers/rules.rs
+++ b/rust/src/enhancers/rules.rs
@@ -10,10 +10,10 @@ use super::matchers::{ExceptionMatcher, FrameMatcher, Matcher};
 use super::{Component, ExceptionData, StacktraceState};
 
 /// An enhancement rule, comprising exception matchers, frame matchers, and actions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Rule(pub(crate) Arc<RuleInner>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// The inner value of a [`Rule`], containing its matchers and actions.
 pub struct RuleInner {
     /// The rule's frame matchers.


### PR DESCRIPTION
This adds support for serializing matchers, actions, and rules to the "config struct" form. In the course of this, it also makes those types `PartialEq/Eq`.