### PR TITLE
Remove `is_sentinel/prefix_frame` from Enhancers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -12,7 +12,7 @@ if [ ! -d .venv ]; then
 
     python3 -m venv .venv
     source .venv/bin/activate
-    pip install $(grep ^-- requirements.txt) --upgrade pip==22.2.2 wheel==0.37.1
+    pip install $(grep ^-- requirements.txt)
     # make develop
 else
     source .venv/bin/activate

--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -47,10 +47,6 @@ pub struct AssembleResult {
 pub struct Component {
     #[pyo3(get, set)]
     contributes: Option<bool>,
-    #[pyo3(get, set)]
-    is_prefix_frame: bool,
-    #[pyo3(get, set)]
-    is_sentinel_frame: bool,
     #[pyo3(get)]
     hint: Option<String>,
 }
@@ -58,12 +54,10 @@ pub struct Component {
 #[pymethods]
 impl Component {
     #[new]
-    #[pyo3(signature = (is_prefix_frame, is_sentinel_frame, contributes=None))]
-    fn new(is_prefix_frame: bool, is_sentinel_frame: bool, contributes: Option<bool>) -> Self {
+    #[pyo3(signature = (contributes=None))]
+    fn new(contributes: Option<bool>) -> Self {
         Self {
             contributes,
-            is_prefix_frame,
-            is_sentinel_frame,
             hint: None,
         }
     }
@@ -173,8 +167,6 @@ impl Enhancements {
             grouping_components.iter_mut().zip(components.into_iter())
         {
             py_component.contributes = rust_component.contributes;
-            py_component.is_prefix_frame = rust_component.is_prefix_frame;
-            py_component.is_sentinel_frame = rust_component.is_sentinel_frame;
             py_component.hint = rust_component.hint;
         }
 
@@ -225,8 +217,6 @@ fn convert_frame_from_py(frame: Bound<'_, PyAny>) -> PyResult<enhancers::Frame> 
 fn convert_component_from_py(component: &Component) -> enhancers::Component {
     enhancers::Component {
         contributes: component.contributes,
-        is_prefix_frame: component.is_prefix_frame,
-        is_sentinel_frame: component.is_sentinel_frame,
         hint: None,
     }
 }

--- a/python/sentry_ophio/enhancers.pyi
+++ b/python/sentry_ophio/enhancers.pyi
@@ -8,12 +8,10 @@ ModificationResult = tuple[str | None, bool | None]
 
 class Component:
     contributes: bool | None
-    is_prefix_frame: bool
-    is_sentinel_frame: bool
     hint: str | None
 
     def __new__(
-        cls, is_prefix_frame: bool, is_sentinel_frame: bool, contributes: bool | None
+        cls, contributes: bool | None
     ) -> Self: ...
 
 

--- a/rust/src/enhancers/actions.rs
+++ b/rust/src/enhancers/actions.rs
@@ -40,10 +40,6 @@ pub enum FlagActionType {
     App,
     /// The `group` flag.
     Group,
-    /// The `prefix` flag.
-    Prefix,
-    /// The `sentinel` flag.
-    Sentinel,
 }
 
 impl fmt::Display for FlagActionType {
@@ -51,8 +47,6 @@ impl fmt::Display for FlagActionType {
         match self {
             FlagActionType::App => write!(f, "app"),
             FlagActionType::Group => write!(f, "group"),
-            FlagActionType::Prefix => write!(f, "prefix"),
-            FlagActionType::Sentinel => write!(f, "sentinel"),
         }
     }
 }
@@ -149,16 +143,6 @@ impl FlagAction {
                         component.hint =
                             Some(format!("marked {state} by stack trace rule ({rule})"));
                     }
-                }
-                FlagActionType::Prefix => {
-                    component.is_prefix_frame = self.flag;
-                    component.hint =
-                        Some(format!("marked as prefix frame by {rule_hint} ({rule})"));
-                }
-                FlagActionType::Sentinel => {
-                    component.is_sentinel_frame = self.flag;
-                    component.hint =
-                        Some(format!("marked as sentinel frame by {rule_hint} ({rule})"));
                 }
             }
         }

--- a/rust/src/enhancers/config_structure.rs
+++ b/rust/src/enhancers/config_structure.rs
@@ -115,8 +115,6 @@ pub enum EncodedAction<'a> {
     ///| ---- | ---------- |
     ///|  00  |   `group`  |
     ///|  01  |    `app`   |
-    ///|  10  |  `prefix`  |
-    ///|  11  | `sentinel` |
     ///
     /// The bits `b10, b9, b8` encode the flag value and the range:
     ///
@@ -144,12 +142,7 @@ impl<'a> EncodedAction<'a> {
         use VarActionValue::*;
         Ok(match self {
             EncodedAction::FlagAction(flag) => {
-                const ACTIONS: &[FlagActionType] = &[
-                    FlagActionType::Group,
-                    FlagActionType::App,
-                    FlagActionType::Prefix,
-                    FlagActionType::Sentinel,
-                ];
+                const ACTIONS: &[FlagActionType] = &[FlagActionType::Group, FlagActionType::App];
                 const FLAGS: &[(bool, Option<Range>)] = &[
                     (true, None),
                     (true, Some(Range::Up)),

--- a/rust/src/enhancers/grammar.rs
+++ b/rust/src/enhancers/grammar.rs
@@ -176,8 +176,6 @@ fn flag_action(input: &str) -> anyhow::Result<(FlagAction, &str)> {
     let ty = match name {
         "app" => FlagActionType::App,
         "group" => FlagActionType::Group,
-        "prefix" => FlagActionType::Prefix,
-        "sentinel" => FlagActionType::Sentinel,
         _ => anyhow::bail!("at `{after_flag}`: invalid flag name `{name}`"),
     };
 

--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -222,8 +222,6 @@ impl Extend<Rule> for Enhancements {
 #[derive(Debug, Clone, Default)]
 pub struct Component {
     pub contributes: Option<bool>,
-    pub is_prefix_frame: bool,
-    pub is_sentinel_frame: bool,
     pub hint: Option<String>,
 }
 

--- a/tests/test_enhancer.py
+++ b/tests/test_enhancer.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping, Optional, Sequence, Union
 
 import pytest
-from sentry_ophio.enhancers import Cache, Component, Enhancements
+from sentry_ophio.enhancers import Cache, Enhancements
 
 # TODO: all this is copied from Sentry, and the Sentry side should still
 # be responsible for the `create_match_frame`
@@ -77,24 +77,6 @@ def test_simple_enhancer():
 
     modified_frames = enhancer.apply_modifications_to_frames(frames, exception_data)
     print(modified_frames)
-
-
-@pytest.mark.parametrize("action", ["+", "-"])
-@pytest.mark.parametrize("type", ["prefix", "sentinel"])
-def test_sentinel_and_prefix(action, type):
-    enhancer = Enhancements.parse(f"function:foo {action}{type}", cache)
-
-    frames = [create_match_frame({"function": "foo"}, "whatever")]
-    frame_components = [Component(contributes=None, is_prefix_frame=False, is_sentinel_frame=False)]
-
-    assert not getattr(frame_components[0], f"is_{type}_frame")
-
-    exception_data = {"ty": None, "value": None, "mechanism": None}
-    enhancer.assemble_stacktrace_component(frames, exception_data,frame_components)
-
-    expected = action == "+"
-    assert getattr(frame_components[0], f"is_{type}_frame") is expected
-
 
 def test_parsing_errors():
     with pytest.raises(RuntimeError, match="failed to parse matchers"):


### PR DESCRIPTION
This was part of hierarchical grouping, which has been deprecated and removed.

It is thus time to also remove these fields and rules from the Rust code.