### PR TITLE
Run release builds on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Release build
 
 on:
   push:
+  pull_request:
 
 jobs:
   linux:
@@ -23,7 +24,6 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
-        if: github.ref == 'refs/heads/release/**'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
@@ -47,7 +47,6 @@ jobs:
           sccache: "true"
 
       - name: Upload wheels
-        if: github.ref == 'refs/heads/release/**'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
@@ -65,7 +64,6 @@ jobs:
           args: --out dist
 
       - name: Upload sdist
-        if: github.ref == 'refs/heads/release/**'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Release build
 
 on:
   push:
-    branches:
-      - "release/**"
 
 jobs:
   linux:
@@ -25,6 +23,7 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
+        if: github.ref == 'refs/heads/release/**'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
@@ -48,6 +47,7 @@ jobs:
           sccache: "true"
 
       - name: Upload wheels
+        if: github.ref == 'refs/heads/release/**'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}
@@ -65,6 +65,7 @@ jobs:
           args: --out dist
 
       - name: Upload sdist
+        if: github.ref == 'refs/heads/release/**'
         uses: actions/upload-artifact@v3
         with:
           name: ${{ github.sha }}


### PR DESCRIPTION
This will help to determine that the build process has not regressed in pull requests.

Notice that the upload step is skipped:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/b065f265-3418-4edc-bc00-e666bc2bc58b">
