### PR TITLE
ci: update artifact actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Release build
 
 on:
   push:
-    branches:
-    - "release/**"
-  pull_request:
+#    branches:
+#    - "release/**"
+#  pull_request:
 
 jobs:
   linux:
@@ -26,10 +26,13 @@ jobs:
           manylinux: auto
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-linux-${{ matrix.target }}
           path: dist
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   macos:
     runs-on: macos-latest
@@ -49,10 +52,13 @@ jobs:
           sccache: "true"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-macos-${{ matrix.target }}
           path: dist
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
 
   sdist:
     runs-on: ubuntu-latest
@@ -66,7 +72,22 @@ jobs:
           args: --out dist
 
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.sha }}
+          name: artifact-sdist
           path: dist
+          if-no-files-found: 'error'
+          # since this artifact will be merged, compression is not necessary
+          compression-level: '0'
+
+  merge:
+    name: Create Release Artifact
+    runs-on: ubuntu-latest
+    needs: [linux, macos, sdist]
+    steps:
+      - uses: actions/upload-artifact/merge@v4
+        with:
+          # Craft expects release assets from github to be a single artifact named after the sha.
+          name: ${{ github.sha }}
+          pattern: artifact-*
+          delete-merged: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Release build
 
 on:
   push:
-#    branches:
-#    - "release/**"
-#  pull_request:
+    branches:
+    - "release/**"
+  pull_request:
 
 jobs:
   linux:


### PR DESCRIPTION
Uses artifacts/merge to merge together multiple artifacts from different jobs into the single one named github.sha that craft expects.

Summarily, upload-artifact v3 is deprecated but v4 doesn't support mutating an artifact with the name name by uploading different filepaths to the same artifact. Because we need a single artifact "github.sha", we have to use actions/merge to create it. Alternatively craft could be modified but this is the easiest way forward and I like the idea of a unified artifact, it makes craft simpler.

ref: https://github.com/getsentry/craft/issues/552
