### PR TITLE
fix(grouping): Allow enhancements version 3

### DIFF
--- a/rust/src/enhancers/mod.rs
+++ b/rust/src/enhancers/mod.rs
@@ -103,8 +103,8 @@ impl Enhancements {
         let EncodedEnhancements(version, _bases, rules) = rmp_serde::from_slice(input)?;
 
         anyhow::ensure!(
-            version == 2,
-            "Rust Enhancements only supports config_structure version `2`"
+            version == 2 || version == 3,
+            "Rust Enhancements only supports config_structure version `2` or `3`"
         );
 
         let all_rules: Vec<_> = rules


### PR DESCRIPTION
This expands the allowed enhancement versions to allow 3, in order to enable the split enhancements experiment in Sentry.