### PR TITLE
chore(dev): Add `.DS_Store` files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.py[cod]
 *.so
 dist/
+.DS_Store


### PR DESCRIPTION
OSX creates `.DS_Store` files to save visual info about the folders in which they reside, but they're unique to each machine, so we shouldn't be committing them.