### PR TITLE
chore(dev): Autoformat `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,34 @@
 [build-system]
-requires = ["maturin>=1.4,<2.0"]
-build-backend = "maturin"
+    requires = ["maturin>=1.4,<2.0"]
+    build-backend = "maturin"
 
 [project]
-name = "sentry_ophio"
-requires-python = ">=3.10"
-license = { text = "Apache-2.0" }
-classifiers = [
-    "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Rust",
-    "Programming Language :: Python :: Implementation :: CPython",
-]
-dynamic = ["version"]
+    name = "sentry_ophio"
+    requires-python = ">=3.10"
+    license = { text = "Apache-2.0" }
+    classifiers = [
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Rust",
+        "Programming Language :: Python :: Implementation :: CPython",
+    ]
+    dynamic = ["version"]
 
 [tool.maturin]
-module-name = "sentry_ophio._bindings"
-manifest-path = "bindings/Cargo.toml"
-python-source = "python"
+    module-name = "sentry_ophio._bindings"
+    manifest-path = "bindings/Cargo.toml"
+    python-source = "python"
 
 [tool.mypy]
-python_version = "3.10"
-plugins = ["pydantic.mypy"]
-files = ["."]
-exclude = ["^.venv/"]
+    python_version = "3.10"
+    plugins = ["pydantic.mypy"]
+    files = ["."]
+    exclude = ["^.venv/"]
 
 [tool.black]
-line-length = 100
-target-version = ['py310']
+    line-length = 100
+    target-version = ['py310']
 
 [tool.isort]
-profile = "black"
-line_length = 100
-lines_between_sections = 1
+    profile = "black"
+    line_length = 100
+    lines_between_sections = 1


### PR DESCRIPTION
This auto-formats the existing `pyproject.toml`, so as not to pollute an upcoming PR making changes to it.