### PR TITLE
fix(dev): Update format of license specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@
 [project]
     name = "sentry_ophio"
     requires-python = ">=3.10"
-    license = { text = "Apache-2.0" }
+    license = "Apache-2.0"
+    license-files = ["LICENSE"]
     classifiers = [
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Rust",


### PR DESCRIPTION
This fixes the way we declare the package license, to bring it in line with the new format specified in [PEP 639](https://peps.python.org/pep-0639/), so that pypi will accept our uploads.