### PR TITLE
fix(dev): Try workaround to get maturin to include license file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dynamic = ["version"]
 module-name = "sentry_ophio._bindings"
 manifest-path = "bindings/Cargo.toml"
 python-source = "python"
+include = [
+    { path = "LICENSE", format = "sdist" }
+]
 
 [tool.mypy]
 python_version = "3.10"


### PR DESCRIPTION
Pypi expects us to declare the license file according to [PEP 639](https://peps.python.org/pep-0639/), but maturin [doesn't yet support it](https://github.com/PyO3/maturin/issues/2531#issuecomment-2833172453). Another maturin user posted [a workaround](https://github.com/PyO3/maturin/issues/2531#issuecomment-2832632196), to try to get maturin to include the license file in the tarball, which this PR implements.

(There is a [draft PR](https://github.com/PyO3/maturin/pull/2571) in the maturin repo to add support for PEP 639, but as of now it seems incomplete. If/when that's completed, merged, and released, we can update maturin and then fix the license specification as is done in https://github.com/getsentry/ophio/pull/80.)