### PR TITLE
fix(lints): Fix a into_iter lint

### DIFF
--- a/bindings/src/enhancers.rs
+++ b/bindings/src/enhancers.rs
@@ -165,9 +165,7 @@ impl Enhancements {
             self.0
                 .assemble_stacktrace_component(&mut components, &frames, &exception_data);
 
-        for (py_component, rust_component) in
-            grouping_components.iter_mut().zip(components.into_iter())
-        {
+        for (py_component, rust_component) in grouping_components.iter_mut().zip(components) {
             py_component.contributes = rust_component.contributes;
             py_component.hint = rust_component.hint;
         }


### PR DESCRIPTION
`cargo clippy --workspace --all-targets --no-deps --all-features --fix`