### PR TITLE
chore(ci): Pin macOS runner to macos-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           compression-level: '0'
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       matrix:
         target: [x86_64, aarch64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-15]
 
     name: Tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub is migrating the macos-latest label to the macOS 26 runner image, rolling out between June 15 and July 15, 2026. Pin the test matrix to macos-15 to stay on the current stable image.